### PR TITLE
Support any StaticVector indexing an Extrapolation

### DIFF
--- a/src/ImageTransformations.jl
+++ b/src/ImageTransformations.jl
@@ -10,7 +10,7 @@ export warp, center
 typealias FloatLike{T<:AbstractFloat} Union{T,Gray{T}}
 typealias FloatColorant{T<:AbstractFloat} Colorant{T}
 
-@inline Base.getindex(A::AbstractExtrapolation, v::SVector) = A[convert(Tuple, v)...]
+@inline Base.getindex(A::AbstractExtrapolation, v::StaticVector) = A[convert(Tuple, v)...]
 
 function warp(img::AbstractExtrapolation, tform)
     inds = autorange(img, tform)


### PR DESCRIPTION
`Tuple()` is part of the `StaticArray` interface. Allows for `MVector` and custom (e.g. `Point`) types.