### PR TITLE
move over restrict from Images

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,5 @@
 julia 0.5
+ImageCore
 CoordinateTransformations
 Interpolations
 OffsetArrays

--- a/src/ImageTransformations.jl
+++ b/src/ImageTransformations.jl
@@ -1,14 +1,20 @@
 module ImageTransformations
 
-using CoordinateTransformations, Interpolations, OffsetArrays, StaticArrays, Colors, ColorVectorSpace
+using CoordinateTransformations, Interpolations, OffsetArrays, StaticArrays, Colors, ColorVectorSpace, ImageCore
 
 import Base: start, next, done, eltype, iteratorsize
-using Base: tail
-
-export warp, center
+using Base: tail, Cartesian
 
 typealias FloatLike{T<:AbstractFloat} Union{T,Gray{T}}
 typealias FloatColorant{T<:AbstractFloat} Colorant{T}
+
+export
+
+    warp,
+    center,
+    restrict
+
+include("resizing.jl")
 
 @inline Base.getindex(A::AbstractExtrapolation, v::StaticVector) = A[convert(Tuple, v)...]
 

--- a/src/ImageTransformations.jl
+++ b/src/ImageTransformations.jl
@@ -12,7 +12,8 @@ export
 
     warp,
     center,
-    restrict
+    restrict,
+    imresize
 
 include("resizing.jl")
 
@@ -91,3 +92,4 @@ center{T,N}(img::AbstractArray{T,N}) = SVector{N}(map(_center, indices(img)))
 _center(ind::AbstractUnitRange) = (first(ind)+last(ind))/2
 
 end # module
+

--- a/src/resizing.jl
+++ b/src/resizing.jl
@@ -127,3 +127,32 @@ end
 
 restrict_size(len::Integer) = isodd(len) ? (len+1)>>1 : (len>>1)+1
 
+## imresize
+function imresize!(resized, original::AbstractMatrix)
+    scale1 = (size(original,1)-1)/(size(resized,1)-0.999f0)
+    scale2 = (size(original,2)-1)/(size(resized,2)-0.999f0)
+    for jr = 0:size(resized,2)-1
+        jo = scale2*jr
+        ijo = trunc(Int, jo)
+        fjo = jo - oftype(jo, ijo)
+        @inbounds for ir = 0:size(resized,1)-1
+            io = scale1*ir
+            iio = trunc(Int, io)
+            fio = io - oftype(io, iio)
+            tmp = (1-fio)*((1-fjo)*original[iio+1,ijo+1] +
+                           fjo*original[iio+1,ijo+2]) +
+                  + fio*((1-fjo)*original[iio+2,ijo+1] +
+                         fjo*original[iio+2,ijo+2])
+            resized[ir+1,jr+1] = convertsafely(eltype(resized), tmp)
+        end
+    end
+    resized
+end
+
+imresize(original, new_size) = size(original) == new_size ? copy!(similar(original), original) : imresize!(similar(original, new_size), original)
+
+convertsafely{T<:AbstractFloat}(::Type{T}, val) = convert(T, val)
+convertsafely{T<:Integer}(::Type{T}, val::Integer) = convert(T, val)
+convertsafely{T<:Integer}(::Type{T}, val::AbstractFloat) = round(T, val)
+convertsafely{T}(::Type{T}, val) = convert(T, val)
+

--- a/src/resizing.jl
+++ b/src/resizing.jl
@@ -1,0 +1,129 @@
+"""
+`imgr = restrict(img[, region])` performs two-fold reduction in size
+along the dimensions listed in `region`, or all spatial coordinates if
+`region` is not specified.  It anti-aliases the image as it goes, so
+is better than a naive summation over 2x2 blocks.
+"""
+restrict(img::AbstractArray, ::Tuple{}) = img
+
+typealias RegionType Union{Dims,Vector{Int}}
+
+function restrict(A::AbstractArray, region::RegionType=coords_spatial(A))
+    for dim in region
+        A = _restrict(A, dim)
+    end
+    A
+end
+
+function _restrict{T,N}(A::AbstractArray{T,N}, dim::Integer)
+    if size(A, dim) <= 2
+        return A
+    end
+    newsz = ntuple(i->i==dim?restrict_size(size(A,dim)):size(A,i), Val{N})
+    out = Array{typeof(A[1]/4+A[2]/2),N}(newsz)
+    restrict!(out, A, dim)
+    out
+end
+
+# out should have efficient linear indexing
+for N = 1:5
+    @eval begin
+        function restrict!{T}(out::AbstractArray{T,$N}, A::AbstractArray, dim)
+            if isodd(size(A, dim))
+                half = convert(eltype(T), 0.5)
+                quarter = convert(eltype(T), 0.25)
+                indx = 0
+                if dim == 1
+                    @inbounds @nloops $N i d->(d==1 ? (1:1) : (1:size(A,d))) d->(j_d = d==1 ? i_d+1 : i_d) begin
+                        nxt = convert(T, @nref $N A j)
+                        out[indx+=1] = half*(@nref $N A i) + quarter*nxt
+                        for k = 3:2:size(A,1)-2
+                            prv = nxt
+                            i_1 = k
+                            j_1 = k+1
+                            nxt = convert(T, @nref $N A j)
+                            out[indx+=1] = quarter*(prv+nxt) + half*(@nref $N A i)
+                        end
+                        i_1 = size(A,1)
+                        out[indx+=1] = quarter*nxt + half*(@nref $N A i)
+                    end
+                else
+                    strd = stride(out, dim)
+                    # Must initialize the i_dim==1 entries with zero
+                    @nexprs $N d->sz_d=d==dim?1:size(out,d)
+                    @nloops $N i d->(1:sz_d) begin
+                        (@nref $N out i) = zero(T)
+                    end
+                    stride_1 = 1
+                    @nexprs $N d->(stride_{d+1} = stride_d*size(out,d))
+                    @nexprs $N d->offset_d = 0
+                    ispeak = true
+                    @inbounds @nloops $N i d->(d==1?(1:1):(1:size(A,d))) d->(if d==dim; ispeak=isodd(i_d); offset_{d-1} = offset_d+(div(i_d+1,2)-1)*stride_d; else; offset_{d-1} = offset_d+(i_d-1)*stride_d; end) begin
+                        indx = offset_0
+                        if ispeak
+                            for k = 1:size(A,1)
+                                i_1 = k
+                                out[indx+=1] += half*(@nref $N A i)
+                            end
+                        else
+                            for k = 1:size(A,1)
+                                i_1 = k
+                                tmp = quarter*(@nref $N A i)
+                                out[indx+=1] += tmp
+                                out[indx+strd] = tmp
+                            end
+                        end
+                    end
+                end
+            else
+                threeeighths = convert(eltype(T), 0.375)
+                oneeighth = convert(eltype(T), 0.125)
+                indx = 0
+                if dim == 1
+                    z = convert(T, zero(A[1]))
+                    @inbounds @nloops $N i d->(d==1 ? (1:1) : (1:size(A,d))) d->(j_d = i_d) begin
+                        c = d = z
+                        for k = 1:size(out,1)-1
+                            a = c
+                            b = d
+                            j_1 = 2*k
+                            i_1 = j_1-1
+                            c = convert(T, @nref $N A i)
+                            d = convert(T, @nref $N A j)
+                            out[indx+=1] = oneeighth*(a+d) + threeeighths*(b+c)
+                        end
+                        out[indx+=1] = oneeighth*c+threeeighths*d
+                    end
+                else
+                    fill!(out, zero(T))
+                    strd = stride(out, dim)
+                    stride_1 = 1
+                    @nexprs $N d->(stride_{d+1} = stride_d*size(out,d))
+                    @nexprs $N d->offset_d = 0
+                    peakfirst = true
+                    @inbounds @nloops $N i d->(d==1?(1:1):(1:size(A,d))) d->(if d==dim; peakfirst=isodd(i_d); offset_{d-1} = offset_d+(div(i_d+1,2)-1)*stride_d; else; offset_{d-1} = offset_d+(i_d-1)*stride_d; end) begin
+                        indx = offset_0
+                        if peakfirst
+                            for k = 1:size(A,1)
+                                i_1 = k
+                                tmp = @nref $N A i
+                                out[indx+=1] += threeeighths*tmp
+                                out[indx+strd] += oneeighth*tmp
+                            end
+                        else
+                            for k = 1:size(A,1)
+                                i_1 = k
+                                tmp = @nref $N A i
+                                out[indx+=1] += oneeighth*tmp
+                                out[indx+strd] += threeeighths*tmp
+                            end
+                        end
+                    end
+                end
+            end
+        end
+    end
+end
+
+restrict_size(len::Integer) = isodd(len) ? (len+1)>>1 : (len>>1)+1
+

--- a/src/resizing.jl
+++ b/src/resizing.jl
@@ -6,16 +6,14 @@ is better than a naive summation over 2x2 blocks.
 """
 restrict(img::AbstractArray, ::Tuple{}) = img
 
-typealias RegionType Union{Dims,Vector{Int}}
-
-function restrict(A::AbstractArray, region::RegionType=coords_spatial(A))
+function restrict(A::AbstractArray, region::Union{Dims,Vector{Int}} = coords_spatial(A))
     for dim in region
-        A = _restrict(A, dim)
+        A = restrict(A, dim)
     end
     A
 end
 
-function _restrict{T,N}(A::AbstractArray{T,N}, dim::Integer)
+function restrict{T,N}(A::AbstractArray{T,N}, dim::Integer)
     if size(A, dim) <= 2
         return A
     end

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,5 +1,6 @@
 ImageCore
 TestImages
+FixedPointNumbers
 @windows ImageMagick
 @linux ImageMagick
 @osx QuartzImageIO

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,12 +1,12 @@
 using ImageTransformations, CoordinateTransformations, TestImages, ImageCore, Colors, FixedPointNumbers
 using Base.Test
 
-#img = testimage("camera")
-#tfm = recenter(RotMatrix(-pi/8), center(img))
-#imgr = warp(img, tfm)
-#@test indices(imgr) == (-78:591, -78:591)
-# imgr2 = warp(imgr, inv(tfm))   # this will need fixes in Interpolations
-# @test imgr2[indices(img)...] ≈ img
+img = testimage("camera")
+tfm = recenter(RotMatrix(-pi/8), center(img))
+imgr = warp(img, tfm)
+@test indices(imgr) == (-78:591, -78:591)
+#imgr2 = warp(imgr, inv(tfm))   # this will need fixes in Interpolations
+#@test imgr2[indices(img)...] ≈ img
 
 @testset "Restriction" begin
     imgcol = colorview(RGB, rand(3,5,6))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,9 +1,50 @@
-using ImageTransformations, CoordinateTransformations, TestImages, ImageCore, Colors
+using ImageTransformations, CoordinateTransformations, TestImages, ImageCore, Colors, FixedPointNumbers
 using Base.Test
 
-img = testimage("camera")
-tfm = recenter(RotMatrix(-pi/8), center(img))
-imgr = warp(img, tfm)
-@test indices(imgr) == (-78:591, -78:591)
+#img = testimage("camera")
+#tfm = recenter(RotMatrix(-pi/8), center(img))
+#imgr = warp(img, tfm)
+#@test indices(imgr) == (-78:591, -78:591)
 # imgr2 = warp(imgr, inv(tfm))   # this will need fixes in Interpolations
 # @test imgr2[indices(img)...] ≈ img
+
+@testset "Restriction" begin
+    imgcol = colorview(RGB, rand(3,5,6))
+    A = reshape([convert(UInt16, i) for i = 1:60], 4, 5, 3)
+    B = restrict(A, (1,2))
+    Btarget = cat(3, [ 0.96875  4.625   5.96875;
+                        2.875   10.5    12.875;
+                        1.90625  5.875   6.90625],
+                    [ 8.46875  14.625 13.46875;
+                    17.875    30.5   27.875;
+                    9.40625  15.875 14.40625],
+                    [15.96875  24.625 20.96875;
+                    32.875    50.5   42.875;
+                    16.90625  25.875 21.90625])
+    @test B ≈ Btarget
+    Argb = reinterpret(RGB, reinterpret(N0f16, permutedims(A, (3,1,2))))
+    B = restrict(Argb)
+    Bf = permutedims(reinterpret(eltype(eltype(B)), B), (2,3,1))
+    @test isapprox(Bf, Btarget/reinterpret(one(N0f16)), atol=1e-12)
+    Argba = reinterpret(RGBA{N0f16}, reinterpret(N0f16, A))
+    B = restrict(Argba)
+    @test isapprox(reinterpret(eltype(eltype(B)), B), restrict(A, (2,3))/reinterpret(one(N0f16)), atol=1e-12)
+    A = reshape(1:60, 5, 4, 3)
+    B = restrict(A, (1,2,3))
+    @test cat(3, [ 2.6015625  8.71875 6.1171875;
+                    4.09375   12.875   8.78125;
+                    3.5390625 10.59375 7.0546875],
+                    [10.1015625 23.71875 13.6171875;
+                    14.09375   32.875   18.78125;
+                    11.0390625 25.59375 14.5546875]) ≈ B
+    #imgcolax = AxisArray(imgcol, :y, :x)
+    #imgr = restrict(imgcolax, (1,2))
+    #@test pixelspacing(imgr) == (2,2)
+    #@test pixelspacing(imgcolax) == (1,1)  # issue #347
+    #@inferred(restrict(imgcolax, Axis{:y}))
+    #@inferred(restrict(imgcolax, Axis{:x}))
+    # Issue #395
+    img1 = colorview(RGB, fill(0.9, 3, 5, 5))
+    img2 = colorview(RGB, fill(N0f8(0.9), 3, 5, 5))
+    @test isapprox(channelview(restrict(img1)), channelview(restrict(img2)), rtol=0.01)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -48,3 +48,14 @@ using Base.Test
     img2 = colorview(RGB, fill(N0f8(0.9), 3, 5, 5))
     @test isapprox(channelview(restrict(img1)), channelview(restrict(img2)), rtol=0.01)
 end
+
+@testset "Image resize" begin
+    img = zeros(10,10)
+    img2 = imresize(img, (5,5))
+    @test length(img2) == 25
+    img = rand(RGB{Float32}, 10, 10)
+    img2 = imresize(img, (6,7))
+    @test size(img2) == (6,7)
+    @test eltype(img2) == RGB{Float32}
+end
+


### PR DESCRIPTION
I am working on moving over `restrict` and `resize` over here from Images.jl

A few question at this point

- What do we do with the `restrict` methods for `AxisArray` and `ImageMetaAxis` (https://github.com/JuliaImages/Images.jl/blob/master/src/algorithms.jl#L516-L531). Do we move them here as well and introduce a dependency on the corresponding packages?

- ~~where does `recenter` in the tests come from, was this some unmerged change somewhere?~~