### PR TITLE
Refactor imresize using Interpolations

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,6 +1,6 @@
 julia 0.5
 ImageCore 0.1.2
-CoordinateTransformations
+CoordinateTransformations 0.4.0
 Interpolations 0.3.7
 OffsetArrays
 StaticArrays

--- a/src/ImageTransformations.jl
+++ b/src/ImageTransformations.jl
@@ -1,3 +1,4 @@
+__precompile__()
 module ImageTransformations
 
 using CoordinateTransformations, Interpolations, OffsetArrays, StaticArrays, Colors, ColorVectorSpace, ImageCore

--- a/src/resizing.jl
+++ b/src/resizing.jl
@@ -147,10 +147,14 @@ end
 
 function imresize!{T,S,N}(resized::AbstractArray{T,N}, original::AbstractArray{S,N})
     itp = interpolate(original, BSpline(Linear()), OnGrid())
+    imresize!(resized, itp)
+end
+
+function imresize!{T,S,N}(resized::AbstractArray{T,N}, original::AbstractInterpolation{S,N})
     sf = map(/, size(original), size(resized))
-    for I in CartesianRange(size(resized))
+    @inbounds for I in CartesianRange(size(resized))
         I_o = map(*, I.I, sf)
-        resized[I] = itp[I_o...]
+        resized[I] = original[I_o...]
     end
     resized
 end

--- a/src/resizing.jl
+++ b/src/resizing.jl
@@ -18,7 +18,10 @@ function restrict{T,N}(A::AbstractArray{T,N}, dim::Integer)
         return A
     end
     newsz = ntuple(i->i==dim?restrict_size(size(A,dim)):size(A,i), Val{N})
-    out = Array{typeof(A[1]/4+A[2]/2),N}(newsz)
+    # FIXME: The following line fails for interpolations because
+    # interpolations can be accessed linearily A[i].
+    #    out = Array{typeof(A[1]/4+A[2]/2),N}(newsz)
+    out = Array{typeof(first(A)/4+first(A)/2),N}(newsz)
     restrict!(out, A, dim)
     out
 end
@@ -78,7 +81,7 @@ for N = 1:5
                 oneeighth = convert(eltype(T), 0.125)
                 indx = 0
                 if dim == 1
-                    z = convert(T, zero(A[1]))
+                    z = convert(T, zero(first(A)))
                     @inbounds @nloops $N i d->(d==1 ? (1:1) : (1:size(A,d))) d->(j_d = i_d) begin
                         c = d = z
                         for k = 1:size(out,1)-1
@@ -125,32 +128,30 @@ end
 
 restrict_size(len::Integer) = isodd(len) ? (len+1)>>1 : (len>>1)+1
 
-## imresize
-function imresize!(resized, original::AbstractMatrix)
-    scale1 = (size(original,1)-1)/(size(resized,1)-0.999f0)
-    scale2 = (size(original,2)-1)/(size(resized,2)-0.999f0)
-    for jr = 0:size(resized,2)-1
-        jo = scale2*jr
-        ijo = trunc(Int, jo)
-        fjo = jo - oftype(jo, ijo)
-        @inbounds for ir = 0:size(resized,1)-1
-            io = scale1*ir
-            iio = trunc(Int, io)
-            fio = io - oftype(io, iio)
-            tmp = (1-fio)*((1-fjo)*original[iio+1,ijo+1] +
-                           fjo*original[iio+1,ijo+2]) +
-                  + fio*((1-fjo)*original[iio+2,ijo+1] +
-                         fjo*original[iio+2,ijo+2])
-            resized[ir+1,jr+1] = convertsafely(eltype(resized), tmp)
-        end
+# imresize
+imresize(original::AbstractArray, dim1, dimN...) = imresize(original, (dim1,dimN...))
+
+function imresize{T,N}(original::AbstractArray{T,N}, short_size::NTuple)
+    len_short = length(short_size)
+    new_size = ntuple(i -> (i > len_short ? size(original,i) : short_size[i]), N)
+    imresize(original, new_size)
+end
+
+function imresize{T,N}(original::AbstractArray{T,N}, new_size::NTuple{N})
+    if size(original) == new_size
+        copy!(similar(original), original)
+    else
+        imresize!(similar(original, new_size), original)
+    end
+end
+
+function imresize!{T,S,N}(resized::AbstractArray{T,N}, original::AbstractArray{S,N})
+    itp = interpolate(original, BSpline(Linear()), OnGrid())
+    sf = map(/, size(original), size(resized))
+    for I in CartesianRange(size(resized))
+        I_o = map(*, I.I, sf)
+        resized[I] = itp[I_o...]
     end
     resized
 end
-
-imresize(original, new_size) = size(original) == new_size ? copy!(similar(original), original) : imresize!(similar(original, new_size), original)
-
-convertsafely{T<:AbstractFloat}(::Type{T}, val) = convert(T, val)
-convertsafely{T<:Integer}(::Type{T}, val::Integer) = convert(T, val)
-convertsafely{T<:Integer}(::Type{T}, val::AbstractFloat) = round(T, val)
-convertsafely{T}(::Type{T}, val) = convert(T, val)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,10 +1,10 @@
 using ImageTransformations, CoordinateTransformations, TestImages, ImageCore, Colors, FixedPointNumbers
 using Base.Test
 
-#img = testimage("camera")
-#tfm = recenter(RotMatrix(-pi/8), center(img))
-#imgr = warp(img, tfm)
-#@test indices(imgr) == (-78:591, -78:591)
+img = testimage("camera")
+tfm = recenter(RotMatrix(-pi/8), center(img))
+imgr = warp(img, tfm)
+@test indices(imgr) == (-78:591, -78:591)
 #imgr2 = warp(imgr, inv(tfm))   # this will need fixes in Interpolations
 #@test imgr2[indices(img)...] ≈ img
 
@@ -12,15 +12,15 @@ using Base.Test
     imgcol = colorview(RGB, rand(3,5,6))
     A = reshape([convert(UInt16, i) for i = 1:60], 4, 5, 3)
     B = restrict(A, (1,2))
-    Btarget = cat(3, [ 0.96875  4.625   5.96875;
-                        2.875   10.5    12.875;
-                        1.90625  5.875   6.90625],
-                    [ 8.46875  14.625 13.46875;
-                    17.875    30.5   27.875;
-                    9.40625  15.875 14.40625],
-                    [15.96875  24.625 20.96875;
-                    32.875    50.5   42.875;
-                    16.90625  25.875 21.90625])
+    Btarget = cat(3, [  0.96875   4.625   5.96875;
+                        2.875    10.5    12.875;
+                        1.90625   5.875   6.90625],
+                     [  8.46875  14.625  13.46875;
+                       17.875    30.5    27.875;
+                        9.40625  15.875  14.40625],
+                     [ 15.96875  24.625  20.96875;
+                       32.875    50.5    42.875;
+                       16.90625  25.875  21.90625])
     @test B ≈ Btarget
     Argb = reinterpret(RGB, reinterpret(N0f16, permutedims(A, (3,1,2))))
     B = restrict(Argb)
@@ -31,12 +31,12 @@ using Base.Test
     @test isapprox(reinterpret(eltype(eltype(B)), B), restrict(A, (2,3))/reinterpret(one(N0f16)), atol=1e-12)
     A = reshape(1:60, 5, 4, 3)
     B = restrict(A, (1,2,3))
-    @test cat(3, [ 2.6015625  8.71875 6.1171875;
-                    4.09375   12.875   8.78125;
-                    3.5390625 10.59375 7.0546875],
-                    [10.1015625 23.71875 13.6171875;
-                    14.09375   32.875   18.78125;
-                    11.0390625 25.59375 14.5546875]) ≈ B
+    @test cat(3, [  2.6015625   8.71875   6.1171875;
+                    4.09375    12.875     8.78125;
+                    3.5390625  10.59375   7.0546875],
+                 [ 10.1015625  23.71875  13.6171875;
+                   14.09375    32.875    18.78125;
+                   11.0390625  25.59375  14.5546875]) ≈ B
     #imgcolax = AxisArray(imgcol, :y, :x)
     #imgr = restrict(imgcolax, (1,2))
     #@test pixelspacing(imgr) == (2,2)


### PR DESCRIPTION
On my plane ride back from a work-related trip, I experimented with writing an `imresize` function using interpolations. The best I could come up with was this approach. It seems to work quite well for upscaling an Image, but when downscaling it, it is more of a sub-sampling than anything, which may not be the best way to do it.

Also, while playing around with Interpolations and Extrapolation (which are both an `AbstractArray` which trigger ImageInTerminal rendering), I noticed that restrict triggered some exceptions. For example one cant to `A[1]` if `A` is an interpolation