### PR TITLE
Improve the coordinate mapping in imresize

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -6,3 +6,4 @@ OffsetArrays
 StaticArrays
 Colors 0.7.0
 ColorVectorSpace 0.2
+FixedPointNumbers 0.3

--- a/src/ImageTransformations.jl
+++ b/src/ImageTransformations.jl
@@ -1,7 +1,7 @@
 __precompile__()
 module ImageTransformations
 
-using CoordinateTransformations, Interpolations, OffsetArrays, StaticArrays, Colors, ColorVectorSpace, ImageCore
+using CoordinateTransformations, Interpolations, OffsetArrays, StaticArrays, FixedPointNumbers, Colors, ColorVectorSpace, ImageCore
 
 import Base: start, next, done, eltype, iteratorsize
 using Base: tail, Cartesian
@@ -93,4 +93,3 @@ center{T,N}(img::AbstractArray{T,N}) = SVector{N}(map(_center, indices(img)))
 _center(ind::AbstractUnitRange) = (first(ind)+last(ind))/2
 
 end # module
-

--- a/src/resizing.jl
+++ b/src/resizing.jl
@@ -1,8 +1,12 @@
 """
-`imgr = restrict(img[, region])` performs two-fold reduction in size
-along the dimensions listed in `region`, or all spatial coordinates if
-`region` is not specified.  It anti-aliases the image as it goes, so
-is better than a naive summation over 2x2 blocks.
+    restrict(img[, region]) -> imgr
+
+Reduce the size of `img` by two-fold along the dimensions listed in
+`region`, or all spatial coordinates if `region` is not specified.  It
+anti-aliases the image as it goes, so is better than a naive summation
+over 2x2 blocks.
+
+See also [`imresize`](@ref).
 """
 restrict(img::AbstractArray, ::Tuple{}) = img
 
@@ -137,6 +141,19 @@ function imresize{T,N}(original::AbstractArray{T,N}, short_size::NTuple)
     imresize(original, new_size)
 end
 
+"""
+    imresize(img, sz) -> imgr
+
+Change `img` to be of size `sz`. This interpolates the values at
+sub-pixel locations. If you are shrinking the image, you risk aliasing
+unless you low-pass filter `img` first. For example:
+
+    σ = map((o,n)->0.75*o/n, size(img), sz)
+    kern = KernelFactors.gaussian(σ)   # from ImageFiltering
+    imgr = imresize(imfilter(img, kern, NA()), sz)
+
+See also [`restrict`](@ref).
+"""
 function imresize{T,N}(original::AbstractArray{T,N}, new_size::NTuple{N})
     Tnew = imresize_type(first(original))
     if size(original) == new_size

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -58,4 +58,3 @@ end
     @test size(img2) == (6,7)
     @test eltype(img2) == RGB{Float32}
 end
-

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -51,10 +51,39 @@ end
 
 @testset "Image resize" begin
     img = zeros(10,10)
-    img2 = imresize(img, (5,5))
+    img2 = @inferred(imresize(img, (5,5)))
     @test length(img2) == 25
     img = rand(RGB{Float32}, 10, 10)
     img2 = imresize(img, (6,7))
     @test size(img2) == (6,7)
     @test eltype(img2) == RGB{Float32}
+
+    A = [1 0; 0 1]
+    @test imresize(A, (1, 1)) ≈ reshape([0.5], 1, 1)
+    # if only 1 of 4 pixels is nonzero, check that you get 1/4 the
+    # value (no matter where it is)
+    for i = 1:4
+        fill!(A, 0)
+        A[i] = 1
+        @test imresize(A, (1, 1)) ≈ reshape([0.25], 1, 1)
+    end
+    A = [1 0; 0 0]
+    @test imresize(A, (2, 1)) ≈ reshape([0.5, 0], (2, 1))
+    @test imresize(A, (1, 2)) ≈ reshape([0.5, 0], (1, 2))
+    A = [1 0 0; 0 0 0; 0 0 0]
+    @test imresize(A, (2, 2)) ≈ [0.75^2 0; 0 0]
+
+    A = Gray{N0f8}[1 0; 0 0]
+    R = imresize(A, (1, 1))
+    @test eltype(R) == Gray{N0f8} && R[1,1] == Gray(N0f8(0.25f0))
+    @test gray.(imresize(A, (2, 1))) ≈ reshape([N0f8(0.5f0), 0], (2, 1))
+    @test gray.(imresize(A, (1, 2))) ≈ reshape([N0f8(0.5f0), 0], (1, 2))
+
+    A = ones(5,5)
+    for l2 = 3:7, l1 = 3:7
+        R = imresize(A, (l1, l2))
+        @test all(x->x==1, R)
+    end
 end
+
+nothing


### PR DESCRIPTION
`imresize` has to decide how points in the resized image correspond to points in the original image. We've had behavior that can be viewed as somewhat inconsistent:
```julia
julia> using Images   # using the old algorithm before it moved to ImageTransformations

julia> import ImageTransformations   # what's currently on master, not this PR

julia> A = [1 0; 0 0]
2×2 Array{Int64,2}:
 1  0
 0  0

julia> Images.imresize(A, (1,1))
1×1 Array{Int64,2}:
 1

julia> ImageTransformations.imresize(A, (1,1))
1×1 Array{Int64,2}:
 0

julia> A = [0 1; 0 0]
2×2 Array{Int64,2}:
 0  1
 0  0

julia> Images.imresize(A, (1,1))
1×1 Array{Int64,2}:
 0

julia> ImageTransformations.imresize(A, (1,1))
1×1 Array{Int64,2}:
 0

julia> A = [0 0; 0 1]
2×2 Array{Int64,2}:
 0  0
 0  1

julia> Images.imresize(A, (1,1))
1×1 Array{Int64,2}:
 0

julia> ImageTransformations.imresize(A, (1,1))
1×1 Array{Int64,2}:
 1
```
With this PR, one gets 0.25 for all of these operations.

For other sizes it will not be quite so invariant, but with this version we at least have a slightly more "principled" choice for how we map coordinates, see https://github.com/JuliaImages/ImageTransformations.jl/blob/d0b802e313240fe5443bcc6d4ed33b9dae22d32a/src/resizing.jl#L160-L169.