### PR TITLE
make wrap preserve eltype of Colorant Arrays

### DIFF
--- a/src/ImageTransformations.jl
+++ b/src/ImageTransformations.jl
@@ -25,6 +25,12 @@ function warp(img::AbstractExtrapolation, tform)
     out = OffsetArray(Array{eltype(img)}(map(length, inds)), inds)
     warp!(out, img, tform)
 end
+function warp{TCol<:Colorant}(img::AbstractArray{TCol}, tform)
+    TNorm = eltype(TCol)
+    apad, pad = Interpolations.prefilter(TNorm, TCol, img, typeof(BSpline(Linear())), typeof(OnGrid()))
+    itp = Interpolations.BSplineInterpolation(TNorm, apad, BSpline(Linear()), OnGrid(), pad)
+    warp(itp, tform)
+end
 warp(img::AbstractArray, tform) = warp(interpolate(img, BSpline(Linear()), OnGrid()), tform)
 warp{T<:FloatLike}(img::AbstractInterpolation{T}, tform) = warp(extrapolate(img, convert(T, NaN)), tform)
 warp{T<:FloatColorant}(img::AbstractInterpolation{T}, tform) = warp(extrapolate(img, nan(T)), tform)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,7 @@ using Base.Test
 img = testimage("camera")
 tfm = recenter(RotMatrix(-pi/8), center(img))
 imgr = warp(img, tfm)
+@test eltype(imgr) == eltype(img)
 @test indices(imgr) == (-78:591, -78:591)
 #imgr2 = warp(imgr, inv(tfm))   # this will need fixes in Interpolations
 #@test imgr2[indices(img)...] ≈ img


### PR DESCRIPTION
It seems more intuitive to me to not promote to Float32 / Float64 automatically if fixed point numbers are used. At least it should be a conscious user decision. We could introduce a signature `wrap(::Type{NewElType}, ...)` to expose that option.

Thoughts?