### PR TITLE
prototype new restrict based on CartesianIndex

### DIFF
--- a/src/ImageTransformations.jl
+++ b/src/ImageTransformations.jl
@@ -17,6 +17,7 @@ export
     imresize
 
 include("resizing.jl")
+include("restrict_old.jl")
 
 @inline Base.getindex(A::AbstractExtrapolation, v::StaticVector) = A[convert(Tuple, v)...]
 

--- a/src/restrict_old.jl
+++ b/src/restrict_old.jl
@@ -1,0 +1,121 @@
+restrict_old(img::AbstractArray, ::Tuple{}) = img
+
+function restrict_old(A::AbstractArray, region::Union{Dims,Vector{Int}} = coords_spatial(A))
+    for dim in region
+        A = restrict_old(A, dim)
+    end
+    A
+end
+
+function restrict_old{T,N}(A::AbstractArray{T,N}, dim::Integer)
+    if size(A, dim) <= 2
+        return A
+    end
+    newsz = ntuple(i->i==dim?restrict_size(size(A,dim)):size(A,i), Val{N})
+    # FIXME: The following line fails for interpolations because
+    # interpolations can not be accessed linearily A[i].
+    #    out = Array{typeof(A[1]/4+A[2]/2),N}(newsz)
+    out = Array{typeof(first(A)/4+first(A)/2),N}(newsz)
+    restrict_old!(out, A, dim)
+    out
+end
+
+# out should have efficient linear indexing
+for N = 1:5
+    @eval begin
+        function restrict_old!{T}(out::AbstractArray{T,$N}, A::AbstractArray, dim)
+            if isodd(size(A, dim))
+                half = convert(eltype(T), 0.5)
+                quarter = convert(eltype(T), 0.25)
+                indx = 0
+                if dim == 1
+                    @inbounds @nloops $N i d->(d==1 ? (1:1) : (1:size(A,d))) d->(j_d = d==1 ? i_d+1 : i_d) begin
+                        nxt = convert(T, @nref $N A j)
+                        out[indx+=1] = half*(@nref $N A i) + quarter*nxt
+                        for k = 3:2:size(A,1)-2
+                            prv = nxt
+                            i_1 = k
+                            j_1 = k+1
+                            nxt = convert(T, @nref $N A j)
+                            out[indx+=1] = quarter*(prv+nxt) + half*(@nref $N A i)
+                        end
+                        i_1 = size(A,1)
+                        out[indx+=1] = quarter*nxt + half*(@nref $N A i)
+                    end
+                else
+                    strd = stride(out, dim)
+                    # Must initialize the i_dim==1 entries with zero
+                    @nexprs $N d->sz_d=d==dim?1:size(out,d)
+                    @nloops $N i d->(1:sz_d) begin
+                        (@nref $N out i) = zero(T)
+                    end
+                    stride_1 = 1
+                    @nexprs $N d->(stride_{d+1} = stride_d*size(out,d))
+                    @nexprs $N d->offset_d = 0
+                    ispeak = true
+                    @inbounds @nloops $N i d->(d==1?(1:1):(1:size(A,d))) d->(if d==dim; ispeak=isodd(i_d); offset_{d-1} = offset_d+(div(i_d+1,2)-1)*stride_d; else; offset_{d-1} = offset_d+(i_d-1)*stride_d; end) begin
+                        indx = offset_0
+                        if ispeak
+                            for k = 1:size(A,1)
+                                i_1 = k
+                                out[indx+=1] += half*(@nref $N A i)
+                            end
+                        else
+                            for k = 1:size(A,1)
+                                i_1 = k
+                                tmp = quarter*(@nref $N A i)
+                                out[indx+=1] += tmp
+                                out[indx+strd] = tmp
+                            end
+                        end
+                    end
+                end
+            else
+                threeeighths = convert(eltype(T), 0.375)
+                oneeighth = convert(eltype(T), 0.125)
+                indx = 0
+                if dim == 1
+                    z = convert(T, zero(first(A)))
+                    @inbounds @nloops $N i d->(d==1 ? (1:1) : (1:size(A,d))) d->(j_d = i_d) begin
+                        c = d = z
+                        for k = 1:size(out,1)-1
+                            a = c
+                            b = d
+                            j_1 = 2*k
+                            i_1 = j_1-1
+                            c = convert(T, @nref $N A i)
+                            d = convert(T, @nref $N A j)
+                            out[indx+=1] = oneeighth*(a+d) + threeeighths*(b+c)
+                        end
+                        out[indx+=1] = oneeighth*c+threeeighths*d
+                    end
+                else
+                    fill!(out, zero(T))
+                    strd = stride(out, dim)
+                    stride_1 = 1
+                    @nexprs $N d->(stride_{d+1} = stride_d*size(out,d))
+                    @nexprs $N d->offset_d = 0
+                    peakfirst = true
+                    @inbounds @nloops $N i d->(d==1?(1:1):(1:size(A,d))) d->(if d==dim; peakfirst=isodd(i_d); offset_{d-1} = offset_d+(div(i_d+1,2)-1)*stride_d; else; offset_{d-1} = offset_d+(i_d-1)*stride_d; end) begin
+                        indx = offset_0
+                        if peakfirst
+                            for k = 1:size(A,1)
+                                i_1 = k
+                                tmp = @nref $N A i
+                                out[indx+=1] += threeeighths*tmp
+                                out[indx+strd] += oneeighth*tmp
+                            end
+                        else
+                            for k = 1:size(A,1)
+                                i_1 = k
+                                tmp = @nref $N A i
+                                out[indx+=1] += oneeighth*tmp
+                                out[indx+strd] += threeeighths*tmp
+                            end
+                        end
+                    end
+                end
+            end
+        end
+    end
+end

--- a/test/restrict_old.jl
+++ b/test/restrict_old.jl
@@ -1,0 +1,13 @@
+@testset "compare against old restrict to check for consistency" begin
+    for img in (testimage("lena_color_256"),
+                testimage("lighthouse"),
+                testimage("camera"),
+                rand(Float32, 10, 11),
+                rand(Float32, 11, 10),
+                rand(Float64, 10, 11),
+                rand(Float64, 11, 10))
+        @test size(restrict(img)) == size(ImageTransformations.restrict_old(img))
+        @test restrict(img) ≈ ImageTransformations.restrict_old(img)
+        @test typeof(restrict(img)) == typeof(ImageTransformations.restrict_old(img))
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -86,4 +86,6 @@ end
     end
 end
 
+include("restrict_old.jl")
+
 nothing


### PR DESCRIPTION
First of all, sorry for the constant noise! I felt it more appropriate to create a PR for just the restrict refactor.

Basically I reimplemented the `restrict!` function using `CartesianIndex` instead of the `Base.Cartesian` macros. I renamed the old implementation to `restrict_old!`.

I managed to get the performance within a factor two/three of the original implementation. I also added regression tests that compare the result against the old implementation

Here are some benchmarks

### Lena image

```julia
julia> @benchmark ImageTransformations.restrict_old($(testimage("lena")))
BenchmarkTools.Trial: 
  memory estimate:  582.84 KiB
  allocs estimate:  40
  --------------
  minimum time:     473.245 μs (0.00% GC)
  median time:      490.146 μs (0.00% GC)
  mean time:        505.872 μs (2.49% GC)
  maximum time:     1.137 ms (47.31% GC)
  --------------
  samples:          9769
  evals/sample:     1
  time tolerance:   5.00%
  memory tolerance: 1.00%

julia> @benchmark ImageTransformations.restrict($(testimage("lena")))
BenchmarkTools.Trial: 
  memory estimate:  582.47 KiB
  allocs estimate:  16
  --------------
  minimum time:     982.108 μs (0.00% GC)
  median time:      1.025 ms (0.00% GC)
  mean time:        1.035 ms (1.16% GC)
  maximum time:     1.620 ms (30.35% GC)
  --------------
  samples:          4800
  evals/sample:     1
  time tolerance:   5.00%
  memory tolerance: 1.00%
```

### Camerman

```julia
julia> @benchmark ImageTransformations.restrict_old($(testimage("camera")))
BenchmarkTools.Trial: 
  memory estimate:  772.72 KiB
  allocs estimate:  32
  --------------
  minimum time:     767.346 μs (0.00% GC)
  median time:      790.394 μs (0.00% GC)
  mean time:        813.456 μs (2.02% GC)
  maximum time:     1.430 ms (34.61% GC)
  --------------
  samples:          6100
  evals/sample:     1
  time tolerance:   5.00%
  memory tolerance: 1.00%

julia> @benchmark ImageTransformations.restrict($(testimage("camera")))
BenchmarkTools.Trial: 
  memory estimate:  772.72 KiB
  allocs estimate:  32
  --------------
  minimum time:     2.495 ms (0.00% GC)
  median time:      2.574 ms (0.00% GC)
  mean time:        2.595 ms (0.64% GC)
  maximum time:     3.213 ms (15.06% GC)
  --------------
  samples:          1922
  evals/sample:     1
  time tolerance:   5.00%
  memory tolerance: 1.00%
```