### PR TITLE
RFC: WarpedView: lazy version of warp. Alternative to TransformedArray

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,9 @@ julia:
 notifications:
   email: false
 # uncomment the following lines to override the default test script
-#script:
-#  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-#  - julia -e 'Pkg.clone(pwd()); Pkg.build("ImageTransformations"); Pkg.test("ImageTransformations"; coverage=true)'
+script:
+  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
+  - julia -e 'Pkg.clone(pwd()); Pkg.build("ImageTransformations"); Pkg.test("ImageTransformations"; coverage=VERSION >= v"0.6.0-alpha")'
 after_success:
   # push coverage results to Codecov
-  - julia -e 'cd(Pkg.dir("ImageTransformations")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'
+  - julia -e 'if VERSION >= v"0.6.0-alpha" cd(Pkg.dir("ImageTransformations")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder()); end'

--- a/REQUIRE
+++ b/REQUIRE
@@ -8,4 +8,4 @@ StaticArrays
 Colors 0.7.0
 ColorVectorSpace 0.2
 FixedPointNumbers 0.3
-Compat 0.18
+Compat 0.19

--- a/REQUIRE
+++ b/REQUIRE
@@ -8,4 +8,5 @@ StaticArrays
 Colors 0.7.0
 ColorVectorSpace 0.2
 FixedPointNumbers 0.3
+ShowItLikeYouBuildIt
 Compat 0.19

--- a/src/ImageTransformations.jl
+++ b/src/ImageTransformations.jl
@@ -1,6 +1,7 @@
 __precompile__()
 module ImageTransformations
 
+using ShowItLikeYouBuildIt
 using ImageCore
 using CoordinateTransformations
 using StaticArrays

--- a/src/ImageTransformations.jl
+++ b/src/ImageTransformations.jl
@@ -18,12 +18,14 @@ export
 
     restrict,
     imresize,
+    center,
     warp,
-    center
+    WarpedView
 
 include("autorange.jl")
 include("resizing.jl")
 include("warp.jl")
+include("warpedview.jl")
 
 center{T,N}(img::AbstractArray{T,N}) = SVector{N}(map(_center, indices(img)))
 _center(ind::AbstractUnitRange) = (first(ind)+last(ind))/2

--- a/src/warpedview.jl
+++ b/src/warpedview.jl
@@ -46,14 +46,10 @@ Base.size(A::WarpedView, d) = OffsetArrays.errmsg(A)
 
 function ShowItLikeYouBuildIt.showarg(io::IO, A::WarpedView)
     print(io, "WarpedView(")
-    showarg(io, _parent(A))
+    showarg(io, parent(A))
     print(io, ", ")
-    showarg(io, A.transform)
+    print(io, A.transform)
     print(io, ')')
 end
-
-_parent(A) = parent(A)
-_parent(A::WarpedView) = _parent(parent(A))
-_parent(A::AbstractInterpolation) = _parent(parent(A))
 
 Base.summary(A::WarpedView) = summary_build(A)

--- a/src/warpedview.jl
+++ b/src/warpedview.jl
@@ -1,0 +1,35 @@
+immutable WarpedView{T,N,A<:AbstractArray,F1<:Transformation,F2<:Transformation,I} <: AbstractArray{T,N}
+    parent::A
+    transform::F1
+    transform_inv::F2
+    indices::I
+
+    function (::Type{WarpedView{T,N,A,F1,F2,I}}){T,N,A<:AbstractArray,F1<:Transformation,F2<:Transformation,I}(
+            parent::A, tform::F1, tinv::F2, indices::I)
+        @assert eltype(parent) == T
+        new{T,N,A,F1,F2,I}(parent, tform, tinv, indices)
+    end
+end
+
+function WarpedView(parent::AbstractArray, args...)
+    WarpedView(interpolate(parent, BSpline(Linear()), OnGrid()), args...)
+end
+
+function WarpedView{T,F<:Transformation}(itp::AbstractInterpolation{T}, tform::F, fill=_default_fill(T))
+    WarpedView(extrapolate(itp, fill), tform)
+end
+
+function WarpedView{T,N,F<:Transformation}(etp::AbstractExtrapolation{T,N}, tform::F)
+    inds = autorange(etp, tform)
+    tinv = inv(tform)
+    WarpedView{T,N,typeof(etp),F,typeof(tinv),typeof(inds)}(etp, tform, tinv, inds)
+end
+
+Base.parent(A::WarpedView)  = A.parent
+@inline Base.indices(A::WarpedView) = A.indices
+
+@compat Compat.IndexStyle{T<:WarpedView}(::Type{T}) = IndexCartesian()
+@inline Base.getindex{N}(A::WarpedView, I::Vararg{Int,N}) = _getindex(A.parent, A.transform_inv(SVector(I)))
+
+Base.size(A::WarpedView)    = OffsetArrays.errmsg(A)
+Base.size(A::WarpedView, d) = OffsetArrays.errmsg(A)

--- a/test/warp.jl
+++ b/test/warp.jl
@@ -1,21 +1,48 @@
-img_square = Gray{N0f8}.(reshape(linspace(0,1,9), (3,3)))
+# helper function to compare NaN
+nearlysame(x, y) = x ≈ y || (isnan(x) & isnan(y))
+nearlysame(A::AbstractArray, B::AbstractArray) = all(map(nearlysame, A, B))
+#img_square = Gray{N0f8}.(reshape(linspace(0,1,9), (3,3)))
+
 img_camera = testimage("camera")
+@testset "Constructor" begin
+    tfm = recenter(RotMatrix(-pi/8), center(img_camera))
+    ref_inds = (-78:591, -78:591)
 
-tfm = recenter(RotMatrix(-pi/8), center(img_camera))
-imgr = @inferred(warp(img_camera, tfm))
-@test indices(imgr) == (-78:591, -78:591)
+    @testset "warp" begin
+        imgr = @inferred(warp(img_camera, tfm))
+        @test indices(imgr) == ref_inds
 
-for T in (Float16,Float32,Float64,
-          N0f8,Gray,Gray{Float16},RGB)
-    imgr = @inferred(warp(T, img_camera, tfm))
-    @test indices(imgr) == (-78:591, -78:591)
-    @test eltype(imgr) <: T
+        for T in (Float16,Float32,Float64,
+                N0f8,Gray,Gray{Float16},RGB)
+            imgr = @inferred(warp(T, img_camera, tfm))
+            @test indices(imgr) == ref_inds
+            @test eltype(imgr) <: T
+        end
+
+        imgr = @inferred(warp(Gray, img_camera, tfm))
+        imgr2 = warp(Gray, imgr, inv(tfm))
+        # look the same but are not similar enough to pass test
+        # @test imgr2[indices(img_camera)...] ≈ img_camera
+    end
+
+    @testset "WarpedView" begin
+        wv = @inferred(WarpedView(img_camera, tfm))
+        @test indices(wv) == ref_inds
+        @test eltype(wv) === eltype(img_camera)
+        @test typeof(parent(wv)) <: Interpolations.AbstractExtrapolation
+        @test typeof(parent(wv).itp) <: Interpolations.AbstractInterpolation
+        @test parent(wv).itp.coefs === img_camera
+
+        # check nested transformation using the inverse
+        wv2 = @inferred(WarpedView(wv, inv(tfm)))
+        @test indices(wv2) == indices(img_camera)
+        @test eltype(wv2) === eltype(img_camera)
+        @test typeof(parent(wv2)) <: Interpolations.AbstractExtrapolation
+        @test typeof(parent(wv2).itp) <: Interpolations.AbstractInterpolation
+        @test parent(wv2).itp.coefs === img_camera
+        @test wv2 ≈ img_camera
+    end
 end
-
-imgr = @inferred(warp(Gray, img_camera, tfm))
-imgr2 = warp(Gray, imgr, inv(tfm))
-# look the same but are not similar enough to pass test
-# @test imgr2[indices(img_camera)...] ≈ img_camera
 
 img_pyramid = Gray{Float64}[
     0.0 0.0 0.0 0.0 0.0;
@@ -24,8 +51,8 @@ img_pyramid = Gray{Float64}[
     0.0 0.5 0.5 0.5 0.0;
     0.0 0.0 0.0 0.0 0.0;
 ]
-
-ref = Float64[
+img_pyramid_cntr = OffsetArray(img_pyramid, -2:2, -2:2)
+ref_img_pyramid = Float64[
     NaN   NaN   NaN   NaN   NaN   NaN   NaN;
     NaN   NaN   NaN  0.172  NaN   NaN   NaN;
     NaN   NaN  0.293 0.543 0.293  NaN   NaN;
@@ -34,30 +61,58 @@ ref = Float64[
     NaN   NaN   NaN  0.172  NaN   NaN   NaN;
     NaN   NaN   NaN   NaN   NaN   NaN   NaN;
 ]
+ref_img_pyramid_quad = Float64[
+    NaN      NaN      NaN      0.003    NaN      NaN      NaN;
+    NaN      NaN     -0.038    0.205   -0.038    NaN      NaN;
+    NaN     -0.038    0.255    0.635    0.255   -0.038    NaN;
+    0.003    0.205    0.635    1.0      0.635    0.205    0.003;
+    NaN     -0.038    0.255    0.635    0.255   -0.038    NaN;
+    NaN      NaN     -0.038    0.205   -0.038    NaN      NaN;
+    NaN      NaN      NaN      0.003    NaN      NaN      NaN;
+]
 
-tfm = recenter(RotMatrix(-pi/4), center(img_pyramid))
-imgr = warp(img_pyramid, tfm)
-@test indices(imgr) == (0:6, 0:6)
+@testset "Result against reference" begin
 
-# Use map and === because of the NaNs
-@test all(map(===, round.(Float64.(parent(imgr)),3), round.(ref,3)))
+    tfm1 = recenter(RotMatrix(-pi/4), center(img_pyramid))
+    tfm2 = LinearMap(RotMatrix(-pi/4))
 
-img_pyramid_cntr = OffsetArray(img_pyramid, -2:2, -2:2)
-tfm = LinearMap(RotMatrix(-pi/4))
-imgr_cntr = warp(img_pyramid_cntr, tfm)
-@test indices(imgr_cntr) == (-3:3, -3:3)
-nearlysame(x, y) = x ≈ y || (isnan(x) & isnan(y))
-@test all(map(nearlysame, parent(imgr_cntr), parent(imgr)))
+    @testset "warp" begin
+        imgr = warp(img_pyramid, tfm1)
+        @test indices(imgr) == (0:6, 0:6)
+        # Use map and === because of the NaNs
+        @test nearlysame(round.(Float64.(parent(imgr)),3), round.(ref_img_pyramid,3))
 
-itp = interpolate(img_pyramid_cntr, BSpline(Quadratic(Flat())), OnCell())
-imgrq_cntr = warp(itp, tfm)
-@test indices(imgrq_cntr) == (-3:3, -3:3)
-refq = Float64[
-    NaN      NaN      NaN      0.003  NaN      NaN      NaN
-    NaN      NaN       -0.038  0.205   -0.038  NaN      NaN
-    NaN       -0.038    0.255  0.635    0.255   -0.038  NaN
-      0.003    0.205    0.635  1.0      0.635    0.205    0.003
-    NaN       -0.038    0.255  0.635    0.255   -0.038  NaN
-    NaN      NaN       -0.038  0.205   -0.038  NaN      NaN
-    NaN      NaN      NaN      0.003  NaN      NaN      NaN]
-@test all(map(===, round.(Float64.(parent(imgrq_cntr)),3), round.(refq,3)))
+        @testset "OffsetArray" begin
+            imgr_cntr = warp(img_pyramid_cntr, tfm2)
+            @test indices(imgr_cntr) == (-3:3, -3:3)
+            @test nearlysame(parent(imgr_cntr), parent(imgr))
+        end
+
+        @testset "Quadratic Interpolation" begin
+            itp = interpolate(img_pyramid_cntr, BSpline(Quadratic(Flat())), OnCell())
+            imgrq_cntr = warp(itp, tfm2)
+            @test indices(imgrq_cntr) == (-3:3, -3:3)
+            @test nearlysame(round.(Float64.(parent(imgrq_cntr)),3), round.(ref_img_pyramid_quad,3))
+        end
+    end
+
+    @testset "WarpedView" begin
+        imgr = WarpedView(img_pyramid, tfm1)
+        @test indices(imgr) == (0:6, 0:6)
+        # Use map and === because of the NaNs
+        @test nearlysame(round.(Float64.(imgr[0:6, 0:6]),3), round.(ref_img_pyramid,3))
+
+        @testset "OffsetArray" begin
+            imgr_cntr = WarpedView(img_pyramid_cntr, tfm2)
+            @test indices(imgr_cntr) == (-3:3, -3:3)
+            @test nearlysame(imgr_cntr[indices(imgr_cntr)...], imgr[indices(imgr)...])
+        end
+
+        @testset "Quadratic Interpolation" begin
+            itp = interpolate(img_pyramid_cntr, BSpline(Quadratic(Flat())), OnCell())
+            imgrq_cntr = WarpedView(itp, tfm2)
+            @test indices(imgrq_cntr) == (-3:3, -3:3)
+            @test nearlysame(round.(Float64.(imgrq_cntr[indices(imgrq_cntr)...]),3), round.(ref_img_pyramid_quad,3))
+        end
+    end
+end

--- a/test/warp.jl
+++ b/test/warp.jl
@@ -11,8 +11,11 @@ for T in (Float16,Float32,Float64,
     @test indices(imgr) == (-78:591, -78:591)
     @test eltype(imgr) <: T
 end
-#imgr2 = warp(imgr, inv(tfm   # this will need fixes in Interpolations
-#@test imgr2[indices(img_camera)...] ≈ img
+
+imgr = @inferred(warp(Gray, img_camera, tfm))
+imgr2 = warp(Gray, imgr, inv(tfm))
+# look the same but are not similar enough to pass test
+# @test imgr2[indices(img_camera)...] ≈ img_camera
 
 img_pyramid = Gray{Float64}[
     0.0 0.0 0.0 0.0 0.0;


### PR DESCRIPTION
I am experimenting with the idea of a view version of `warp`. this is a raw draft, but it works.
I am unsure if this package is the right place, but it can't hurt to throw the idea out there

- Ideally I would like to allow it to unroll nested `WarpedView` calls by composing transformations. 

- Maybe `warpedview` could dispatch on `::WarpedView` and compose the transformations instead of nesting views. Seems to be in line with the `ImageCore` design.

any thoughts on this?
