### PR TITLE
make restrict a generated function and fix convert bug

### DIFF
--- a/src/resizing.jl
+++ b/src/resizing.jl
@@ -31,97 +31,95 @@ function restrict{T,N}(A::AbstractArray{T,N}, dim::Integer)
 end
 
 # out should have efficient linear indexing
-for N = 1:5
-    @eval begin
-        function restrict!{T}(out::AbstractArray{T,$N}, A::AbstractArray, dim)
-            if isodd(size(A, dim))
-                half = convert(eltype(T), 0.5)
-                quarter = convert(eltype(T), 0.25)
-                indx = 0
-                if dim == 1
-                    @inbounds @nloops $N i d->(d==1 ? (1:1) : (1:size(A,d))) d->(j_d = d==1 ? i_d+1 : i_d) begin
+@generated function restrict!{T,N}(out::AbstractArray{T,N}, A::AbstractArray, dim)
+    quote
+        if isodd(size(A, dim))
+            half = convert(eltype(T), 0.5)
+            quarter = convert(eltype(T), 0.25)
+            indx = 0
+            if dim == 1
+                @inbounds @nloops $N i d->(d==1 ? (1:1) : (1:size(A,d))) d->(j_d = d==1 ? i_d+1 : i_d) begin
+                    nxt = convert(T, @nref $N A j)
+                    out[indx+=1] = half*convert(T, @nref $N A i) + quarter*nxt
+                    for k = 3:2:size(A,1)-2
+                        prv = nxt
+                        i_1 = k
+                        j_1 = k+1
                         nxt = convert(T, @nref $N A j)
-                        out[indx+=1] = half*(@nref $N A i) + quarter*nxt
-                        for k = 3:2:size(A,1)-2
-                            prv = nxt
+                        out[indx+=1] = quarter*(prv+nxt) + half*convert(T, @nref $N A i)
+                    end
+                    i_1 = size(A,1)
+                    out[indx+=1] = quarter*nxt + half*convert(T, @nref $N A i)
+                end
+            else
+                strd = stride(out, dim)
+                # Must initialize the i_dim==1 entries with zero
+                @nexprs $N d->sz_d=d==dim?1:size(out,d)
+                @nloops $N i d->(1:sz_d) begin
+                    (@nref $N out i) = zero(T)
+                end
+                stride_1 = 1
+                @nexprs $N d->(stride_{d+1} = stride_d*size(out,d))
+                @nexprs $N d->offset_d = 0
+                ispeak = true
+                @inbounds @nloops $N i d->(d==1?(1:1):(1:size(A,d))) d->(if d==dim; ispeak=isodd(i_d); offset_{d-1} = offset_d+(div(i_d+1,2)-1)*stride_d; else; offset_{d-1} = offset_d+(i_d-1)*stride_d; end) begin
+                    indx = offset_0
+                    if ispeak
+                        for k = 1:size(A,1)
                             i_1 = k
-                            j_1 = k+1
-                            nxt = convert(T, @nref $N A j)
-                            out[indx+=1] = quarter*(prv+nxt) + half*(@nref $N A i)
+                            out[indx+=1] += half*convert(T, @nref $N A i)
                         end
-                        i_1 = size(A,1)
-                        out[indx+=1] = quarter*nxt + half*(@nref $N A i)
-                    end
-                else
-                    strd = stride(out, dim)
-                    # Must initialize the i_dim==1 entries with zero
-                    @nexprs $N d->sz_d=d==dim?1:size(out,d)
-                    @nloops $N i d->(1:sz_d) begin
-                        (@nref $N out i) = zero(T)
-                    end
-                    stride_1 = 1
-                    @nexprs $N d->(stride_{d+1} = stride_d*size(out,d))
-                    @nexprs $N d->offset_d = 0
-                    ispeak = true
-                    @inbounds @nloops $N i d->(d==1?(1:1):(1:size(A,d))) d->(if d==dim; ispeak=isodd(i_d); offset_{d-1} = offset_d+(div(i_d+1,2)-1)*stride_d; else; offset_{d-1} = offset_d+(i_d-1)*stride_d; end) begin
-                        indx = offset_0
-                        if ispeak
-                            for k = 1:size(A,1)
-                                i_1 = k
-                                out[indx+=1] += half*(@nref $N A i)
-                            end
-                        else
-                            for k = 1:size(A,1)
-                                i_1 = k
-                                tmp = quarter*(@nref $N A i)
-                                out[indx+=1] += tmp
-                                out[indx+strd] = tmp
-                            end
+                    else
+                        for k = 1:size(A,1)
+                            i_1 = k
+                            tmp = quarter*convert(T, @nref $N A i)
+                            out[indx+=1] += tmp
+                            out[indx+strd] = tmp
                         end
                     end
                 end
-            else
-                threeeighths = convert(eltype(T), 0.375)
-                oneeighth = convert(eltype(T), 0.125)
-                indx = 0
-                if dim == 1
-                    z = convert(T, zero(first(A)))
-                    @inbounds @nloops $N i d->(d==1 ? (1:1) : (1:size(A,d))) d->(j_d = i_d) begin
-                        c = d = z
-                        for k = 1:size(out,1)-1
-                            a = c
-                            b = d
-                            j_1 = 2*k
-                            i_1 = j_1-1
-                            c = convert(T, @nref $N A i)
-                            d = convert(T, @nref $N A j)
-                            out[indx+=1] = oneeighth*(a+d) + threeeighths*(b+c)
-                        end
-                        out[indx+=1] = oneeighth*c+threeeighths*d
+            end
+        else
+            threeeighths = convert(eltype(T), 0.375)
+            oneeighth = convert(eltype(T), 0.125)
+            indx = 0
+            if dim == 1
+                z = convert(T, zero(first(A)))
+                @inbounds @nloops $N i d->(d==1 ? (1:1) : (1:size(A,d))) d->(j_d = i_d) begin
+                    c = d = z
+                    for k = 1:size(out,1)-1
+                        a = c
+                        b = d
+                        j_1 = 2*k
+                        i_1 = j_1-1
+                        c = convert(T, @nref $N A i)
+                        d = convert(T, @nref $N A j)
+                        out[indx+=1] = oneeighth*(a+d) + threeeighths*(b+c)
                     end
-                else
-                    fill!(out, zero(T))
-                    strd = stride(out, dim)
-                    stride_1 = 1
-                    @nexprs $N d->(stride_{d+1} = stride_d*size(out,d))
-                    @nexprs $N d->offset_d = 0
-                    peakfirst = true
-                    @inbounds @nloops $N i d->(d==1?(1:1):(1:size(A,d))) d->(if d==dim; peakfirst=isodd(i_d); offset_{d-1} = offset_d+(div(i_d+1,2)-1)*stride_d; else; offset_{d-1} = offset_d+(i_d-1)*stride_d; end) begin
-                        indx = offset_0
-                        if peakfirst
-                            for k = 1:size(A,1)
-                                i_1 = k
-                                tmp = @nref $N A i
-                                out[indx+=1] += threeeighths*tmp
-                                out[indx+strd] += oneeighth*tmp
-                            end
-                        else
-                            for k = 1:size(A,1)
-                                i_1 = k
-                                tmp = @nref $N A i
-                                out[indx+=1] += oneeighth*tmp
-                                out[indx+strd] += threeeighths*tmp
-                            end
+                    out[indx+=1] = oneeighth*c+threeeighths*d
+                end
+            else
+                fill!(out, zero(T))
+                strd = stride(out, dim)
+                stride_1 = 1
+                @nexprs $N d->(stride_{d+1} = stride_d*size(out,d))
+                @nexprs $N d->offset_d = 0
+                peakfirst = true
+                @inbounds @nloops $N i d->(d==1?(1:1):(1:size(A,d))) d->(if d==dim; peakfirst=isodd(i_d); offset_{d-1} = offset_d+(div(i_d+1,2)-1)*stride_d; else; offset_{d-1} = offset_d+(i_d-1)*stride_d; end) begin
+                    indx = offset_0
+                    if peakfirst
+                        for k = 1:size(A,1)
+                            i_1 = k
+                            tmp = convert(T, @nref $N A i)
+                            out[indx+=1] += threeeighths*tmp
+                            out[indx+strd] += oneeighth*tmp
+                        end
+                    else
+                        for k = 1:size(A,1)
+                            i_1 = k
+                            tmp = convert(T, @nref $N A i)
+                            out[indx+=1] += oneeighth*tmp
+                            out[indx+strd] += threeeighths*tmp
                         end
                     end
                 end


### PR DESCRIPTION
I am afraid the indentation change makes the diff very hard to read.

basically I only did two things:

1. made `restrict` a generated function
2. made sure that all `@nref $N A i` are surrounded by `convert(T,...)` this seems to fix the huge performance overhead described at https://github.com/JuliaImages/ImageTransformations.jl/pull/12#issuecomment-287180807

```julia
julia> img = testimage("cameraman")[1:511,1:511];

julia> out = zeros(restrict(img, 1));

julia> @benchmark ImageTransformations.restrict!($out, $img, 1)
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     865.264 μs (0.00% GC)
  median time:      909.404 μs (0.00% GC)
  mean time:        903.599 μs (0.00% GC)
  maximum time:     1.732 ms (0.00% GC)
  --------------
  samples:          5499
  evals/sample:     1
  time tolerance:   5.00%
  memory tolerance: 1.00%
```

🎉 