### PR TITLE
Support arbitrary indices

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,7 +1,8 @@
 julia 0.5
 ImageCore 0.1.2
 CoordinateTransformations 0.4.0
-Interpolations 0.3.7
+Interpolations 0.4
+AxisAlgorithms
 OffsetArrays
 StaticArrays
 Colors 0.7.0

--- a/src/ImageTransformations.jl
+++ b/src/ImageTransformations.jl
@@ -4,7 +4,7 @@ module ImageTransformations
 using ImageCore
 using CoordinateTransformations
 using StaticArrays
-using Interpolations
+using Interpolations, AxisAlgorithms
 using OffsetArrays
 using FixedPointNumbers
 using Colors, ColorVectorSpace

--- a/src/warp.jl
+++ b/src/warp.jl
@@ -39,3 +39,15 @@ function warp!(out, img::AbstractExtrapolation, tform)
     end
     out
 end
+
+# This is type-piracy, but necessary if we want Interpolations to be
+# independent of OffsetArrays.
+function AxisAlgorithms.A_ldiv_B_md!(dest::OffsetArray, F, src::OffsetArray, dim::Integer, b::AbstractVector)
+    indsdim = indices(parent(src), dim)
+    indsF = indices(F)[2]
+    if indsF == indsdim
+        AxisAlgorithms.A_ldiv_B_md!(parent(dest), F, parent(src), dim, b)
+        return dest
+    end
+    throw(DimensionMismatch("indices $(indices(parent(src))) do not match $(indices(F))"))
+end

--- a/test/autorange.jl
+++ b/test/autorange.jl
@@ -113,4 +113,17 @@ end
             @test rnge[2].stop  == ceil(cos(α-ϕ)*d)
         end
     end
+    # Non-1 indices
+    for (indh, indw) in ((-1:10,0:20), (-1:20,-2:10), (0:7,-3:9))
+        h, w = length(indh), length(indw)
+        tst_img = OffsetArray(zeros(h,w), indh, indw)
+        for ϕ in deg2rad.(1:1:89)
+            rot = LinearMap(RotMatrix(ϕ))
+            rnge = @inferred ImageTransformations.autorange(tst_img, rot)
+            @test rnge[1].start == floor(cos(ϕ)*first(indh) - sin(ϕ)*last(indw))
+            @test rnge[1].stop  ==  ceil(cos(ϕ)*last(indh)  - sin(ϕ)*first(indw))
+            @test rnge[2].start == floor(sin(ϕ)*first(indh) + cos(ϕ)*first(indw))
+            @test rnge[2].stop  ==  ceil(sin(ϕ)*last(indh)  + cos(ϕ)*last(indw))
+        end
+    end
 end

--- a/test/resizing.jl
+++ b/test/resizing.jl
@@ -1,5 +1,5 @@
 @testset "Restriction" begin
-    A = reshape([convert(UInt16, i) for i = 1:60], 4, 5, 3)
+    A = reshape([UInt16(i) for i = 1:60], 4, 5, 3)
     B = restrict(A, (1,2))
     Btarget = cat(3, [  0.96875   4.625   5.96875;
                         2.875    10.5    12.875;
@@ -30,6 +30,14 @@
     img1 = colorview(RGB, fill(0.9, 3, 5, 5))
     img2 = colorview(RGB, fill(N0f8(0.9), 3, 5, 5))
     @test isapprox(channelview(restrict(img1)), channelview(restrict(img2)), rtol=0.01)
+    # Non-1 indices
+    Ao = OffsetArray(A, (-2,1,0))
+    @test parent(@inferred(restrict(Ao, 1))) == restrict(A, 1)
+    @test parent(@inferred(restrict(Ao, 2))) == restrict(A, 2)
+    @test parent(@inferred(restrict(Ao, (1,2)))) == restrict(A, (1,2))
+    # Arrays-of-arrays
+    a = Vector{Int}[[3,3,3], [2,1,7],[-11,4,2]]
+    @test restrict(a) == Vector{Float64}[[2,3.5/2,6.5/2], [-5,4.5/2,5.5/2]]
 end
 
 @testset "Image resize" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using ImageTransformations, CoordinateTransformations, TestImages, ImageCore, Colors, FixedPointNumbers
+using ImageTransformations, CoordinateTransformations, TestImages, ImageCore, Colors, FixedPointNumbers, OffsetArrays, Interpolations
 using Base.Test
 
 tests = [


### PR DESCRIPTION
This leverages recent changes in Interpolations (https://github.com/JuliaMath/Interpolations.jl/pull/146) to provide support for arbitrary indices in warping. It also rewrites `restrict` to support arbitrary indices. Note that this very similar to https://github.com/JuliaImages/ImageTransformations.jl/pull/12, but by keeping any branches out of the innermost loop and by circumventing https://github.com/JuliaLang/julia/issues/9080, I've been able to keep the performance essentially unchanged (less than 10% difference).
