### PR TITLE
restrict: split dimension default into a separate function

### DIFF
--- a/src/resizing.jl
+++ b/src/resizing.jl
@@ -11,7 +11,8 @@ See also [`imresize`](@ref).
 restrict(img::AbstractArray, ::Tuple{}) = img
 
 restrict(A::AbstractArray, region::Vector{Int}) = restrict(A, (region...))
-function restrict(A::AbstractArray, region::Dims = coords_spatial(A))
+restrict(A::AbstractArray) = restrict(A, coords_spatial(A))
+function restrict(A::AbstractArray, region::Dims)
     restrict(restrict(A, region[1]), Base.tail(region))
 end
 


### PR DESCRIPTION
In preparation for a more orthogonal solution to https://github.com/JuliaImages/Images.jl/pull/628. After this, methods only have to consider `::Dims` for the second argument.