### PR TITLE
Ensure SVector construction preserves dimensionality of CartesianIndex

### DIFF
--- a/src/autorange.jl
+++ b/src/autorange.jl
@@ -1,8 +1,8 @@
 function autorange(img, tform)
     R = CartesianRange(indices(img))
-    mn = mx = tform(SVector(first(R)))
+    mn = mx = tform(SVector(first(R).I))
     for I in CornerIterator(R)
-        x = tform(SVector(I))
+        x = tform(SVector(I.I))
         # we map min and max to prevent type-inference issues
         # (because min(::SVector,::SVector) -> Vector)
         mn = map(min, x, mn)

--- a/src/warp.jl
+++ b/src/warp.jl
@@ -96,7 +96,7 @@ end
 function warp!(out, img::AbstractExtrapolation, tform)
     tinv = inv(tform)
     for I in CartesianRange(indices(out))
-        out[I] = _getindex(img, tinv(SVector(I)))
+        out[I] = _getindex(img, tinv(SVector(I.I)))
     end
     out
 end


### PR DESCRIPTION
`SVector` used to have a method so that `SVector(i::CartesianIndex)` created a vector of the components of `i`, but that method seems to be gone in StaticArrays 0.4. Since there are situations in which you'd want to create an `SVector` of `CartesianIndex`es, I'm not surprised this changed; it seems to be best to be explicit here about our intention.