### PR TITLE
Special treatment for SubArray of InvWarpedView

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -5,6 +5,7 @@ Interpolations 0.4
 AxisAlgorithms
 OffsetArrays
 StaticArrays
+IdentityRanges
 Colors 0.7.0
 ColorVectorSpace 0.2
 FixedPointNumbers 0.3

--- a/src/ImageTransformations.jl
+++ b/src/ImageTransformations.jl
@@ -10,6 +10,7 @@ using OffsetArrays
 using FixedPointNumbers
 using Colors, ColorVectorSpace
 using Compat
+using IdentityRanges
 
 import Base: start, next, done, eltype, iteratorsize, size, length
 using Base: tail, Cartesian, Indices

--- a/src/autorange.jl
+++ b/src/autorange.jl
@@ -1,5 +1,9 @@
 function autorange(img, tform)
     R = CartesianRange(indices(img))
+    autorange(R, tform)
+end
+
+function autorange(R::CartesianRange, tform)
     mn = mx = tform(SVector(first(R).I))
     for I in CornerIterator(R)
         x = tform(SVector(I.I))

--- a/src/invwarpedview.jl
+++ b/src/invwarpedview.jl
@@ -135,9 +135,15 @@ function invwarpedview(
     invwarpedview(A, tinv, indices, Linear(), fill)
 end
 
-function invwarpedview{T,N,W<:InvWarpedView,F<:Transformation}(inner_view::SubArray{T,N,W}, tinv::F)
+function invwarpedview{T,N,W<:InvWarpedView}(inner_view::SubArray{T,N,W}, tinv::Transformation)
     inner = parent(inner_view)
     new_inner = InvWarpedView(inner, tinv, autorange(inner, tinv))
     inds = autorange(CartesianRange(inner_view.indexes), tinv)
-    view(new_inner, inds...)
+    view(new_inner, map(IdentityRange, inds)...)
+end
+
+function invwarpedview{T,N,W<:InvWarpedView}(inner_view::SubArray{T,N,W}, tinv::Transformation, indices::Tuple)
+    inner = parent(inner_view)
+    new_inner = InvWarpedView(inner, tinv, autorange(inner, tinv))
+    view(new_inner, indices...)
 end


### PR DESCRIPTION
Context: For a use-case of mine I'd like to lazily be able to 1.) chain affine transformations, and 2.) allow for cropping in-between these operations. While 1. is already possible with `InvWarpedView` (after the merge of #24 ), point 2. is a little inconvenient right now, as it requires nesting `SubArray` and `InvWarpedView` over and over.

With this PR the package would employ special treatment for `invwarpedview(::SubArray{T,N,<:InvWarpedView}, ...)` in which it makes sure that only one `SubArray` of a single `InvWarpedView` is used.

```julia
julia> using ImageTransformations, CoordinateTransformations, Rotations, ImageInTerminal, TestImages, StaticArrays

julia> img_camera = testimage("camera");

julia> tfm = recenter(RotMatrix(-pi/8), center(img_camera))
AffineMap([0.92388 0.382683; -0.382683 0.92388], [-78.6334,117.683])

julia> iwv = invwarpedview(img_camera, tfm)
```

<img width="638" alt="screen shot 2017-05-03 at 16 01 00" src="https://cloud.githubusercontent.com/assets/10854026/25664152/0cbf5fce-301a-11e7-8d4b-6ec38bdf7810.png">

```julia
julia> v = view(iwv, 1:512, -70:400)
```

<img width="638" alt="screen shot 2017-05-03 at 16 01 52" src="https://cloud.githubusercontent.com/assets/10854026/25664150/0ca4bc28-301a-11e7-974f-5138a4943d9e.png">

```julia
julia> tfm2 = LinearMap(SMatrix{2,2}([1 0; 0 .5]))
LinearMap([1.0 0.0; 0.0 0.5])

julia> v2 = invwarpedview(v, tfm2)
```

<img width="640" alt="screen shot 2017-05-03 at 16 02 31" src="https://cloud.githubusercontent.com/assets/10854026/25664151/0ca68418-301a-11e7-87fa-f1ea318d328e.png">

Here the last result (`v2`) looks equivalent to the result of `invwarpedview(collect(v), tfm2)`.
Naturally that is in general not the case, as `collect` throws away information that is otherwise secretly preserved underneath. But I don't think that keeping this information is a downside. Here is an example for what I mean:

```julia
julia> tfm3 = LinearMap(SMatrix{2,2}([1 0; .5 1]))
LinearMap([1.0 0.0; 0.5 1.0])

julia> v3 = invwarpedview(v2, tfm3)
``` 

<img width="629" alt="screen shot 2017-05-03 at 16 07 42" src="https://cloud.githubusercontent.com/assets/10854026/25664449/ebe07e86-301a-11e7-969d-099ec57a58e2.png">

```julia
julia> v4 = invwarpedview(collect(v2), tfm3)
``` 

<img width="629" alt="screen shot 2017-05-03 at 16 08 45" src="https://cloud.githubusercontent.com/assets/10854026/25664460/f24fb3d6-301a-11e7-9b2b-369b34a1ee38.png">
