### PR TITLE
Make tests pass even when julia is started without --color=yes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ notifications:
 # uncomment the following lines to override the default test script
 script:
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-  - julia --color=yes -e 'Pkg.clone(pwd()); Pkg.build("ImageTransformations"); Pkg.test("ImageTransformations"; coverage=VERSION >= v"0.6.0-alpha")'
+  - julia -e 'Pkg.clone(pwd()); Pkg.build("ImageTransformations"); Pkg.test("ImageTransformations"; coverage=VERSION >= v"0.6.0-alpha")'
 after_success:
   # push coverage results to Codecov
   - julia -e 'if VERSION >= v"0.6.0-alpha" cd(Pkg.dir("ImageTransformations")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder()); end'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,4 +32,4 @@ build_script:
       Pkg.clone(pwd(), \"ImageTransformations\"); Pkg.build(\"ImageTransformations\")"
 
 test_script:
-  - C:\projects\julia\bin\julia --color=yes -e "Pkg.test(\"ImageTransformations\")"
+  - C:\projects\julia\bin\julia -e "Pkg.test(\"ImageTransformations\")"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,7 +9,13 @@ ambs = detect_ambiguities(ImageTransformations, CoordinateTransformations, Base,
 reference_path(filename) = joinpath(dirname(@__FILE__), "reference", "$(filename).txt")
 
 function test_reference_impl{T<:Colorant}(filename, img::AbstractArray{T})
-    res = ImageInTerminal.encodeimg(ImageInTerminal.SmallBlocks(), ImageInTerminal.TermColor256(), img, 20, 40)[1]
+    old_color = Base.have_color
+    res = try
+        eval(Base, :(have_color = true))
+        ImageInTerminal.encodeimg(ImageInTerminal.SmallBlocks(), ImageInTerminal.TermColor256(), img, 20, 40)[1]
+    finally
+        eval(Base, :(have_color = $old_color))
+    end
     test_reference_impl(filename, res)
 end
 


### PR DESCRIPTION
kinda messy, but seems to work - Base could use a better scoped API for this at some point