### PR TITLE
Fix reparamterization of CartesianRange on 0.7

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -10,4 +10,4 @@ Colors 0.7.0
 ColorVectorSpace 0.2
 FixedPointNumbers 0.3
 ShowItLikeYouBuildIt
-Compat 0.19
+Compat 0.29

--- a/src/autorange.jl
+++ b/src/autorange.jl
@@ -22,7 +22,7 @@ immutable CornerIterator{I<:CartesianIndex}
     start::I
     stop::I
 end
-CornerIterator{I<:CartesianIndex}(R::CartesianRange{I}) = CornerIterator{I}(first(R), last(R))
+CornerIterator(R::CartesianRange) = CornerIterator(first(R), last(R))
 
 eltype{I}(::Type{CornerIterator{I}}) = I
 iteratorsize{I}(::Type{CornerIterator{I}}) = Base.HasShape()

--- a/src/resizing.jl
+++ b/src/resizing.jl
@@ -259,6 +259,6 @@ end
 @inline map3(f, a, b, c) = (f(a[1], b[1], c[1]), map3(f, tail(a), tail(b), tail(c))...)
 @inline map3(f, ::Tuple{}, ::Tuple{}, ::Tuple{}) = ()
 
-function clampR{N}(I::NTuple{N}, R::CartesianRange{CartesianIndex{N}})
+@compat function clampR{N}(I::NTuple{N}, R::CartesianRange{N})
     map3(clamp, I, first(R).I, last(R).I)
 end


### PR DESCRIPTION
Doesn't pass tests on 0.7, but that wasn't really my goal here. Fixes https://github.com/JuliaImages/Images.jl/issues/653. 