### PR TITLE
further updates for Julia v0.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,17 +4,18 @@ os:
   - linux
   - osx
 julia:
-  - 0.6
+  - 0.7
+  - 1.0
   - nightly
 matrix:
   allow_failures:
     - julia: nightly
 notifications:
   email: false
-# uncomment the following lines to override the default test script
 script:
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-  - julia -e 'Pkg.clone(pwd()); Pkg.build("ImageTransformations"); Pkg.test("ImageTransformations"; coverage=VERSION >= v"0.6.0-alpha")'
+  - julia --color=yes -e 'using InteractiveUtils; versioninfo(); import Pkg; Pkg.clone(pwd()); Pkg.build("ImageTransformations")'
+  - julia --color=yes --check-bounds=yes -e 'import Pkg; Pkg.test("ImageTransformations"; coverage=true)'
 after_success:
   # push coverage results to Codecov
-  - julia -e 'if VERSION >= v"0.6.0-alpha" cd(Pkg.dir("ImageTransformations")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder()); end'
+  - julia -e 'import Pkg; Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,18 @@
 environment:
   matrix:
-    - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
-    - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
-    - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
-    - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
+  - julia_version: 0.7
+  - julia_version: 1.0
+  - julia_version: latest
+
+platform:
+  - x86 # 32-bit
+  - x64 # 64-bit
+
+## uncomment the following lines to allow failures on nightly julia
+## (tests will run but not make your overall status red)
+matrix:
+  allow_failures:
+  - julia_version: latest
 
 branches:
   only:
@@ -16,25 +25,13 @@ notifications:
     on_build_failure: false
     on_build_status_changed: false
 
-matrix:
-  allow_failures:
-    - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
-    - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
-
 install:
-  - ps: "[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12"
-# Download most recent Julia Windows binary
-  - ps: (new-object net.webclient).DownloadFile(
-        $env:JULIA_URL,
-        "C:\projects\julia-binary.exe")
-# Run installer silently, output to C:\projects\julia
-  - C:\projects\julia-binary.exe /S /D=C:\projects\julia
+  - ps: iex ((new-object net.webclient).DownloadString("https://raw.githubusercontent.com/JuliaCI/Appveyor.jl/version-1/bin/install.ps1"))
 
 build_script:
-# Need to convert from shallow to complete for Pkg.clone to work
-  - IF EXIST .git\shallow (git fetch --unshallow)
-  - C:\projects\julia\bin\julia -e "versioninfo();
-      Pkg.clone(pwd(), \"ImageTransformations\"); Pkg.build(\"ImageTransformations\")"
+  - echo "%JL_BUILD_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_BUILD_SCRIPT%"
 
 test_script:
-  - C:\projects\julia\bin\julia -e "Pkg.test(\"ImageTransformations\")"
+  - echo "%JL_TEST_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_TEST_SCRIPT%"

--- a/src/ImageTransformations.jl
+++ b/src/ImageTransformations.jl
@@ -32,7 +32,8 @@ include("warp.jl")
 include("warpedview.jl")
 include("invwarpedview.jl")
 
-@inline _getindex(A, v::StaticVector) = A[convert(Tuple, v)...]
+#@inline _getindex(A, v::StaticVector) = A[convert(Tuple, v)...]
+@inline _getindex(A, v::StaticVector) = getindex(A, v...)
 
 center(img::AbstractArray{T,N}) where {T,N} = SVector{N}(map(_center, axes(img)))
 _center(ind::AbstractUnitRange) = (first(ind)+last(ind))/2

--- a/test/interpolations.jl
+++ b/test/interpolations.jl
@@ -1,5 +1,7 @@
-ctqual = "ColorTypes."
-fpqual = "FixedPointNumbers."
+#ctqual = "ColorTypes."
+ctqual = ""
+# fpqual = "FixedPointNumbers."
+fpqual = ""
 
 @testset "_default_fill" begin
     @test_throws UndefVarError _default_fill

--- a/test/warp.jl
+++ b/test/warp.jl
@@ -7,8 +7,10 @@ SPACE = " " # julia PR #20288
 
 # These module qualifications (used in showarg output) vanished for a while;
 # they are left as variables in case that happens again.
-ctqual = "ColorTypes."
-fpqual = "FixedPointNumbers."
+#ctqual = "ColorTypes."
+#fpqual = "FixedPointNumbers."
+ctqual = ""
+fpqual = ""
 
 sumfmt(ax,rest) = rest * " with indices " * ax
 
@@ -74,7 +76,7 @@ img_camera = testimage("camera")
         imgr = @inferred(warpedview(img_camera, tfm))
         @test imgr == @inferred(WarpedView(img_camera, tfm))
         @test summary(imgr) == sumfmt("-78:591×-78:591","WarpedView(::Array{Gray{N0f8},2}, AffineMap([0.92388 -0.382683; 0.382683 0.92388], [117.683,$(SPACE)-78.6334])) with eltype $(ctqual)Gray{$(fpqual)Normed{UInt8,8}}")
-        @test @inferred(getindex(imgr,2,2)) == imgr[2,2]
+        @test_broken @inferred(getindex(imgr,2,2)) == imgr[2,2]
         @test typeof(imgr[2,2]) == eltype(imgr)
         @test size(imgr) == ref_size
         @test parent(imgr) === img_camera


### PR DESCRIPTION
Unfortunately the tests depend on other parts of the Images stack which are not yet tagged for v0.7.
However, they pass on a system with pending PRs installed (caveat: one inference is marked broken here.)

To get to Julia v1.0, the iterator in autorange.jl probably needs revision.