### PR TITLE
minor cleanups for Julia 1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,6 @@ matrix:
     - julia: nightly
 notifications:
   email: false
-script:
-  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-  - julia --color=yes -e 'using InteractiveUtils; versioninfo(); import Pkg; Pkg.clone(pwd()); Pkg.build("ImageTransformations")'
-  - julia --color=yes --check-bounds=yes -e 'import Pkg; Pkg.test("ImageTransformations"; coverage=true)'
 after_success:
   # push coverage results to Codecov
   - julia -e 'import Pkg; Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'

--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 # ImageTransformations
 
 [![Build Status](https://travis-ci.org/JuliaImages/ImageTransformations.jl.svg?branch=master)](https://travis-ci.org/JuliaImages/ImageTransformations.jl)
-
 [![Build status](https://ci.appveyor.com/api/projects/status/afjwnok18l3ou38a/branch/master?svg=true)](https://ci.appveyor.com/project/timholy/imagetransformations-jl/branch/master)
-
 [![codecov.io](http://codecov.io/github/JuliaImages/ImageTransformations.jl/coverage.svg?branch=master)](http://codecov.io/github/JuliaImages/ImageTransformations.jl?branch=master)
 
 This package provides support for image resizing, image rotation, and

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,6 +1,6 @@
 TestImages
 FixedPointNumbers 0.3.0
-ReferenceTests
+ReferenceTests 0.4.0
 @windows ImageMagick
 @linux ImageMagick
 @osx QuartzImageIO


### PR DESCRIPTION
* Use the default Travis script, which should be a bit more future-proof
* Remove some unnecessary blank lines in the readme (this causes the badges to all display in a line instead of in separate paragraphs)
* Bump the ReferenceTests requirement to get some Julia 1.0 fixes