### PR TITLE
Let `imresize` throw `MethodError` instead of `StackoverflowError`

### DIFF
--- a/src/resizing.jl
+++ b/src/resizing.jl
@@ -175,7 +175,9 @@ function imresize(original::AbstractArray; ratio::Real)
     imresize(original, new_size)
 end
 
+# temporary patch for issue #57
 imresize(original::AbstractArray, short_size::Tuple{T,Vararg{T}}) where T<:AbstractFloat = throw(MethodError(imresize, original, short_size))
+
 function imresize(original::AbstractArray, short_size::Tuple)
     len_short = length(short_size)
     len_short > ndims(original) && throw(DimensionMismatch("$short_size has too many dimensions for a $(ndims(original))-dimensional array"))

--- a/src/resizing.jl
+++ b/src/resizing.jl
@@ -175,7 +175,7 @@ function imresize(original::AbstractArray; ratio::Real)
     imresize(original, new_size)
 end
 
-imresize(original::AbstractArray, short_size::Tuple{T,Vararg{T}}) where T<:Real = throw(MethodError(imresize, original, short_size))
+imresize(original::AbstractArray, short_size::Tuple{T,Vararg{T}}) where T<:AbstractFloat = throw(MethodError(imresize, original, short_size))
 function imresize(original::AbstractArray, short_size::Tuple)
     len_short = length(short_size)
     len_short > ndims(original) && throw(DimensionMismatch("$short_size has too many dimensions for a $(ndims(original))-dimensional array"))

--- a/src/resizing.jl
+++ b/src/resizing.jl
@@ -175,10 +175,7 @@ function imresize(original::AbstractArray; ratio::Real)
     imresize(original, new_size)
 end
 
-# temporary patch for issue #57
-imresize(original::AbstractArray, short_size::Tuple{T,Vararg{T}}) where T<:AbstractFloat = throw(MethodError(imresize, original, short_size))
-
-function imresize(original::AbstractArray, short_size::Tuple)
+function imresize(original::AbstractArray, short_size::Union{Indices{M},Dims{M}}) where M
     len_short = length(short_size)
     len_short > ndims(original) && throw(DimensionMismatch("$short_size has too many dimensions for a $(ndims(original))-dimensional array"))
     new_size = ntuple(i -> (i > len_short ? odims(original, i, short_size) : short_size[i]), ndims(original))

--- a/src/resizing.jl
+++ b/src/resizing.jl
@@ -175,8 +175,7 @@ function imresize(original::AbstractArray; ratio::Real)
     imresize(original, new_size)
 end
 
-imresize(original::AbstractArray, short_size::Tuple{T,Vararg{T}}) where T<:AbstractFloat = throw(MethodError(imresize, original, short_size))
-function imresize(original::AbstractArray, short_size::Tuple)
+function imresize(original::AbstractArray, short_size::Tuple{T,Vararg{T}}) where T <: Union{Integer, AbstractUnitRange}
     len_short = length(short_size)
     len_short > ndims(original) && throw(DimensionMismatch("$short_size has too many dimensions for a $(ndims(original))-dimensional array"))
     new_size = ntuple(i -> (i > len_short ? odims(original, i, short_size) : short_size[i]), ndims(original))

--- a/src/resizing.jl
+++ b/src/resizing.jl
@@ -175,7 +175,8 @@ function imresize(original::AbstractArray; ratio::Real)
     imresize(original, new_size)
 end
 
-function imresize(original::AbstractArray, short_size::Tuple{T,Vararg{T}}) where T <: Union{Integer, AbstractUnitRange}
+imresize(original::AbstractArray, short_size::Tuple{T,Vararg{T}}) where T<:Real = throw(MethodError(imresize, original, short_size))
+function imresize(original::AbstractArray, short_size::Tuple)
     len_short = length(short_size)
     len_short > ndims(original) && throw(DimensionMismatch("$short_size has too many dimensions for a $(ndims(original))-dimensional array"))
     new_size = ntuple(i -> (i > len_short ? odims(original, i, short_size) : short_size[i]), ndims(original))

--- a/src/resizing.jl
+++ b/src/resizing.jl
@@ -169,11 +169,9 @@ end
 
 # imresize
 imresize(original::AbstractArray, dim1::T, dimN::T...) where T<:Union{Integer,AbstractUnitRange} = imresize(original, (dim1,dimN...))
-imresize(original::AbstractArray, short_size::AbstractArray{T,1}) where T <:Union{Integer,AbstractUnitRange} = imresize(original, (short_size...))
-
-function imresize(original::AbstractArray, ratio::Real)
-    # use ceil to avoid 0
-    new_size = ratio > 0 ? ceil.(Int, size(original).* ratio) : throw(ArgumentError("$ratio should be positive"))
+function imresize(original::AbstractArray; ratio::Real)
+    ratio > 0 || throw(ArgumentError("ratio $ratio should be positive"))
+    new_size = ceil.(Int, size(original) .* ratio) # use ceil to avoid 0
     imresize(original, new_size)
 end
 
@@ -191,30 +189,23 @@ odims(original, i, short_size) = oftype(first(short_size), axes(original, i))
 """
     imresize(img, sz) -> imgr
     imresize(img, inds) -> imgr
-    imresize(img, ratio::Real) -> imgr
+    imresize(img; ratio) -> imgr
 
 Change `img` to be of size `sz` (or to have indices `inds`). If `ratio` is used, then
 `sz = ceil(Int, size(img).*ratio)`. This interpolates the values at sub-pixel locations.
 If you are shrinking the image, you risk aliasing unless you low-pass filter `img` first.
 
-# Example:
+# Examples
 ```julia
 julia> img = testimage("lena_gray_256") # 256*256
 julia> imresize(img, 128, 128) # 128*128
 julia> imresize(img, 1:128, 1:128) # 128*128
-julia> imresize(img, [128, 128]) # 128*128
-julia> imresize(img, [1:128, 1:128]) # 128*128
 julia> imresize(img, (128, 128)) # 128*128
 julia> imresize(img, (1:128, 1:128)) # 128*128
 julia> imresize(img, (1:128, )) # 128*256
 julia> imresize(img, 128) # 128*256
-julia> imresize(img, 0.5) # 128*128
+julia> imresize(img, ratio = 0.5) # 128*128
 ```
-
-!!! info
-
-    for N-dimensional image/signal, `imresize(img, arg)` treats `arg::Real` as `ratio`, and `arg::Integer` as `sz`. In the latter case, only the first dimension will be resized.
-
 
 See also [`restrict`](@ref).
 """

--- a/src/resizing.jl
+++ b/src/resizing.jl
@@ -204,6 +204,10 @@ julia> imresize(img, (1:128, 1:128)) # 128*128
 julia> imresize(img, (1:128, )) # 128*256
 julia> imresize(img, 128) # 128*256
 julia> imresize(img, ratio = 0.5) # 128*128
+
+σ = map((o,n)->0.75*o/n, size(img), sz)
+kern = KernelFactors.gaussian(σ)   # from ImageFiltering
+imgr = imresize(imfilter(img, kern, NA()), sz)
 ```
 
 See also [`restrict`](@ref).

--- a/test/resizing.jl
+++ b/test/resizing.jl
@@ -78,8 +78,7 @@ end
 
             @test_throws MethodError imresize(img,5.0,5.0)
             @test_throws MethodError imresize(img,(5.0,5.0))
-            # @test_throws MethodError imresize(img,(5,5.0))
-            @test_broken imresize(img,(5, 5.0)) # FIXME: still throw StackOverflowError
+            @test_throws MethodError imresize(img,(5, 5.0))
             @test_throws MethodError imresize(img,[5,5])
             @test_throws UndefKeywordError imresize(img)
             @test_throws DimensionMismatch imresize(img,(5,5,5))

--- a/test/resizing.jl
+++ b/test/resizing.jl
@@ -51,68 +51,91 @@
 end
 
 @testset "Image resize" begin
-    img = zeros(10,10)
-    img2 = @inferred(imresize(img, (5,5)))
-    @test length(img2) == 25
-    img2 = imresize(img, 5)
-    @test size(img2) == (5,10)
-    img = rand(RGB{Float32}, 10, 10)
-    img2 = imresize(img, (6,7))
-    @test size(img2) == (6,7)
-    @test eltype(img2) == RGB{Float32}
+    testcolor = (RGB,Gray)
+    testtype = (Float32, Float64, N0f8, N0f16)
 
-    A = [1 0; 0 1]
-    @test imresize(A, (1, 1)) ≈ reshape([0.5], 1, 1)
-    # if only 1 of 4 pixels is nonzero, check that you get 1/4 the
-    # value (no matter where it is)
-    for i = 1:4
-        fill!(A, 0)
-        A[i] = 1
-        @test imresize(A, (1, 1)) ≈ reshape([0.25], 1, 1)
-    end
-    A = [1 0; 0 0]
-    @test imresize(A, (2, 1)) ≈ reshape([0.5, 0], (2, 1))
-    @test imresize(A, (1, 2)) ≈ reshape([0.5, 0], (1, 2))
-    A = [1 0 0; 0 0 0; 0 0 0]
-    @test imresize(A, (2, 2)) ≈ [0.75^2 0; 0 0]
+    @testset "Interface" begin
+        function test_imresize_interface(img, outsz, args...)
+            img2 = @test_broken @inferred imresize(img, args...) # FIXME: @inferred failed
+            img2 = @test_nowarn imresize(img, args...)
+            @test size(img2) == outsz
+            @test eltype(img2) == eltype(img)
+        end
+        for C in testcolor, T in testtype
+            img = rand(C{T},10,10)
 
-    A = Gray{N0f8}[1 0; 0 0]
-    R = imresize(A, (1, 1))
-    @test eltype(R) == Gray{N0f8} && R[1,1] == Gray(N0f8(0.25f0))
-    @test gray.(imresize(A, (2, 1))) ≈ reshape([N0f8(0.5f0), 0], (2, 1))
-    @test gray.(imresize(A, (1, 2))) ≈ reshape([N0f8(0.5f0), 0], (1, 2))
+            test_imresize_interface(img, (5,5), (5,5))
+            test_imresize_interface(img, (5,5), (1:5,1:5)) # FIXME: @inferred failed
+            test_imresize_interface(img, (5,5), [5,5]) # FIXME: @inferred failed
+            test_imresize_interface(img, (5,5), [1:5,1:5]) # FIXME: @inferred failed
+            test_imresize_interface(img, (5,5), 5,5)
+            test_imresize_interface(img, (5,5), 1:5,1:5) # FIXME: @inferred failed
+            test_imresize_interface(img, (5,5), 0.5)
+            test_imresize_interface(img, (5,10), 5)
+            test_imresize_interface(img, (5,10), 1:5) # FIXME: @inferred failed
+            test_imresize_interface(img, (5,10), (1:5,)) # FIXME: @inferred failed
+            test_imresize_interface(img, (5,10), [1:5,]) # FIXME: @inferred failed
 
-    A = ones(5,5)
-    for l2 = 3:7, l1 = 3:7
-        R = imresize(A, (l1, l2))
-        @test all(x->x==1, R)
+            @test_throws MethodError imresize(img,(5.0,5.0))
+            @test_throws DimensionMismatch imresize(img,(5,5,5))
+            @test_throws ArgumentError imresize(img, -0.5)
+            @test_throws DimensionMismatch imresize(img,(5,5,1))
+        end
     end
-    for l2 = 3:7, l1 = 3:7
-        R = imresize(A, (0:l1-1, 0:l2-1))
-        @test all(x->x==1, R)
-        @test axes(R) == (0:l1-1, 0:l2-1)
+
+    @testset "Numerical" begin
+        # RGB is skipped
+        for C in (Gray,), T in testtype
+            A = [1 0; 0 1] .|> C{T}
+            @test imresize(A, (1, 1)) ≈ reshape([0.5], 1, 1) .|> C{T}
+            # if only 1 of 4 pixels is nonzero, check that you get 1/4 the
+            # value (no matter where it is)
+            for i = 1:4
+                fill!(A, 0)
+                A[i] = 1
+                A = C{T}.(A)
+                @test imresize(A, (1, 1)) ≈ reshape([0.25], 1, 1) .|> C{T}
+            end
+            A = [1 0; 0 0] .|> C{T}
+            @test imresize(A, (2, 1)) ≈ reshape([0.5, 0], (2, 1)) .|> C{T}
+            @test imresize(A, (1, 2)) ≈ reshape([0.5, 0], (1, 2)) .|> C{T}
+            A = [1 0 0; 0 0 0; 0 0 0] .|> C{T}
+            @test imresize(A, (2, 2)) ≈ [0.75^2 0; 0 0] .|> C{T}
+
+            A = ones(5,5) .|> C{T}
+            for l2 = 3:7, l1 = 3:7
+                R = imresize(A, (l1, l2))
+                @test all(x->x==1, R)
+            end
+            for l2 = 3:7, l1 = 3:7
+                R = imresize(A, (0:l1-1, 0:l2-1))
+                @test all(x->x==1, R)
+                @test axes(R) == (0:l1-1, 0:l2-1)
+            end
+            for l1 = 3:7
+                R = imresize(A, (0:l1-1,))
+                @test all(x->x==1, R)
+                @test axes(R) == (0:l1-1, 1:5)
+            end
+
+            R = imresize(A, (2:6, 0:4))
+            @test all(x->x==1, R)
+            @test axes(R) == (2:6, 0:4)
+            R = imresize(A, ())
+            @test all(x->x==1, R)
+            @test axes(R) == axes(A)
+            @test !(R === A)
+            Ao = OffsetArray(A, -2:2, 0:4)
+            R = imresize(Ao, (5,5))
+            @test axes(R) === axes(A)
+            R = imresize(Ao, axes(Ao))
+            @test axes(R) === axes(Ao)
+            @test !(R === A)
+            img = reshape([0.5])
+            R = imresize(img, ())
+            @test ndims(R) == 0
+            @test !(R === A)
+            @test_throws DimensionMismatch imresize(img, 3, 7)
+        end
     end
-    for l1 = 3:7
-        R = imresize(A, (0:l1-1,))
-        @test all(x->x==1, R)
-        @test axes(R) == (0:l1-1, 1:5)
-    end
-    R = imresize(A, (2:6, 0:4))
-    @test all(x->x==1, R)
-    @test axes(R) == (2:6, 0:4)
-    R = imresize(A, ())
-    @test all(x->x==1, R)
-    @test axes(R) == axes(A)
-    @test !(R === A)
-    Ao = OffsetArray(A, -2:2, 0:4)
-    R = imresize(Ao, (5,5))
-    @test axes(R) === axes(A)
-    R = imresize(Ao, axes(Ao))
-    @test axes(R) === axes(Ao)
-    @test !(R === A)
-    img = reshape([0.5])
-    R = imresize(img, ())
-    @test ndims(R) == 0
-    @test !(R === A)
-    @test_throws DimensionMismatch imresize(img, 3, 7)
 end

--- a/test/resizing.jl
+++ b/test/resizing.jl
@@ -76,6 +76,7 @@ end
             test_imresize_interface(img, (5,10), 1:5) # FIXME: @inferred failed
             test_imresize_interface(img, (5,10), (1:5,)) # FIXME: @inferred failed
 
+            @test_throws MethodError imresize(img,5.0,5.0)
             @test_throws MethodError imresize(img,(5.0,5.0))
             # @test_throws MethodError imresize(img,(5,5.0))
             @test_broken imresize(img,(5, 5.0)) # FIXME: still throw StackOverflowError

--- a/test/resizing.jl
+++ b/test/resizing.jl
@@ -55,9 +55,9 @@ end
     testtype = (Float32, Float64, N0f8, N0f16)
 
     @testset "Interface" begin
-        function test_imresize_interface(img, outsz, args...)
-            img2 = @test_broken @inferred imresize(img, args...) # FIXME: @inferred failed
-            img2 = @test_nowarn imresize(img, args...)
+        function test_imresize_interface(img, outsz, args...; kargs...)
+            img2 = @test_broken @inferred imresize(img, args...; kargs...) # FIXME: @inferred failed
+            img2 = @test_nowarn imresize(img, args...; kargs...)
             @test size(img2) == outsz
             @test eltype(img2) == eltype(img)
         end
@@ -66,19 +66,18 @@ end
 
             test_imresize_interface(img, (5,5), (5,5))
             test_imresize_interface(img, (5,5), (1:5,1:5)) # FIXME: @inferred failed
-            test_imresize_interface(img, (5,5), [5,5]) # FIXME: @inferred failed
-            test_imresize_interface(img, (5,5), [1:5,1:5]) # FIXME: @inferred failed
             test_imresize_interface(img, (5,5), 5,5)
             test_imresize_interface(img, (5,5), 1:5,1:5) # FIXME: @inferred failed
-            test_imresize_interface(img, (5,5), 0.5)
+            test_imresize_interface(img, (5,5), ratio = 0.5)
+            test_imresize_interface(img, (20,20), ratio = 2)
             test_imresize_interface(img, (5,10), 5)
             test_imresize_interface(img, (5,10), 1:5) # FIXME: @inferred failed
             test_imresize_interface(img, (5,10), (1:5,)) # FIXME: @inferred failed
-            test_imresize_interface(img, (5,10), [1:5,]) # FIXME: @inferred failed
 
             @test_throws MethodError imresize(img,(5.0,5.0))
+            @test_throws MethodError imresize(img,[5,5])
             @test_throws DimensionMismatch imresize(img,(5,5,5))
-            @test_throws ArgumentError imresize(img, -0.5)
+            @test_throws ArgumentError imresize(img, ratio = -0.5)
             @test_throws DimensionMismatch imresize(img,(5,5,1))
         end
     end

--- a/test/resizing.jl
+++ b/test/resizing.jl
@@ -75,6 +75,7 @@ end
             test_imresize_interface(img, (5,10), (1:5,)) # FIXME: @inferred failed
 
             @test_throws MethodError imresize(img,(5.0,5.0))
+            @test_throws MethodError imresize(img,(5,5.0))
             @test_throws MethodError imresize(img,[5,5])
             @test_throws DimensionMismatch imresize(img,(5,5,5))
             @test_throws ArgumentError imresize(img, ratio = -0.5)

--- a/test/resizing.jl
+++ b/test/resizing.jl
@@ -70,13 +70,17 @@ end
             test_imresize_interface(img, (5,5), 1:5,1:5) # FIXME: @inferred failed
             test_imresize_interface(img, (5,5), ratio = 0.5)
             test_imresize_interface(img, (20,20), ratio = 2)
+            test_imresize_interface(img, (10,10), ())
             test_imresize_interface(img, (5,10), 5)
+            test_imresize_interface(img, (5,10), (5,))
             test_imresize_interface(img, (5,10), 1:5) # FIXME: @inferred failed
             test_imresize_interface(img, (5,10), (1:5,)) # FIXME: @inferred failed
 
             @test_throws MethodError imresize(img,(5.0,5.0))
-            @test_throws MethodError imresize(img,(5,5.0))
+            # @test_throws MethodError imresize(img,(5,5.0))
+            @test_broken imresize(img,(5, 5.0)) # FIXME: still throw StackOverflowError
             @test_throws MethodError imresize(img,[5,5])
+            @test_throws UndefKeywordError imresize(img)
             @test_throws DimensionMismatch imresize(img,(5,5,5))
             @test_throws ArgumentError imresize(img, ratio = -0.5)
             @test_throws DimensionMismatch imresize(img,(5,5,1))
@@ -135,7 +139,6 @@ end
             R = imresize(img, ())
             @test ndims(R) == 0
             @test !(R === A)
-            @test_throws DimensionMismatch imresize(img, 3, 7)
         end
     end
 end


### PR DESCRIPTION
1. fix issue #57 
2. add a `imresize(img, ratio)` function
3. ~add support for array, `imresize(img, [256,256])` falls back to `imresize(img,(256,256))`.~
3. rewrite the testset of imresize

FIXME:
* `imresize` is not type stable with `UnitRange`, e.g., `@inffered imresize(img, 1:256)` would raise error. I set these test as `@test_broken`