### PR TITLE
fix _getindex type stability

### DIFF
--- a/src/ImageTransformations.jl
+++ b/src/ImageTransformations.jl
@@ -32,8 +32,7 @@ include("warp.jl")
 include("warpedview.jl")
 include("invwarpedview.jl")
 
-#@inline _getindex(A, v::StaticVector) = A[convert(Tuple, v)...]
-@inline _getindex(A, v::StaticVector) = getindex(A, v...)
+@inline _getindex(A, v::StaticVector) = A[Tuple(v)...]
 
 center(img::AbstractArray{T,N}) where {T,N} = SVector{N}(map(_center, axes(img)))
 _center(ind::AbstractUnitRange) = (first(ind)+last(ind))/2

--- a/test/interpolations.jl
+++ b/test/interpolations.jl
@@ -51,6 +51,9 @@ end
     @test etp.fillvalue === Gray{N0f8}(0.0)
     @test etp.itp.coefs === img
 
+    # to catch regressions like #60
+    @test @inferred(ImageTransformations._getindex(img, @SVector([1,2]))) isa Gray{N0f8}
+
     @test_throws ArgumentError ImageTransformations.box_extrapolation(etp, 0)
     @test_throws ArgumentError ImageTransformations.box_extrapolation(etp, Flat())
     @test_throws ArgumentError ImageTransformations.box_extrapolation(etp, Quadratic(Flat()))

--- a/test/warp.jl
+++ b/test/warp.jl
@@ -76,7 +76,7 @@ img_camera = testimage("camera")
         imgr = @inferred(warpedview(img_camera, tfm))
         @test imgr == @inferred(WarpedView(img_camera, tfm))
         @test_skip summary(imgr) == sumfmt("-78:591×-78:591","WarpedView(::Array{Gray{N0f8},2}, AffineMap([0.92388 -0.382683; 0.382683 0.92388], [117.683,$(SPACE)-78.6334])) with eltype $(ctqual)Gray{$(fpqual)Normed{UInt8,8}}")
-        @test_broken @inferred(getindex(imgr,2,2)) == imgr[2,2]
+        @test @inferred(getindex(imgr,2,2)) == imgr[2,2]
         @test typeof(imgr[2,2]) == eltype(imgr)
         @test size(imgr) == ref_size
         @test parent(imgr) === img_camera


### PR DESCRIPTION
closes #60 reported by @jianghaizhu

in 1.0:

```
julia> @btime warp(img, tfm);
  344.735 μs (5 allocations: 157.72 KiB)
```