### PR TITLE
Update for Interpolations 0.9

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,7 +1,7 @@
 julia 0.7
 ImageCore 0.7
 CoordinateTransformations 0.4.0
-Interpolations 0.4
+Interpolations 0.9
 AxisAlgorithms
 OffsetArrays
 StaticArrays

--- a/src/ImageTransformations.jl
+++ b/src/ImageTransformations.jl
@@ -33,6 +33,7 @@ include("warpedview.jl")
 include("invwarpedview.jl")
 
 @inline _getindex(A, v::StaticVector) = A[Tuple(v)...]
+@inline _getindex(A::AbstractInterpolation, v::StaticVector) = A(Tuple(v)...)
 
 center(img::AbstractArray{T,N}) where {T,N} = SVector{N}(map(_center, axes(img)))
 _center(ind::AbstractUnitRange) = (first(ind)+last(ind))/2

--- a/src/interpolations.jl
+++ b/src/interpolations.jl
@@ -23,12 +23,13 @@ function box_extrapolation(itp::AbstractInterpolation{T}, fill::FillType = _defa
 end
 
 function box_extrapolation(parent::AbstractArray{T,N}, degree::D = Linear(), args...) where {T,N,D<:Union{Linear,Constant}}
-    itp = Interpolations.BSplineInterpolation{T,N,typeof(parent),BSpline{D},OnGrid,0}(parent)
+    axs = axes(parent)
+    itp = Interpolations.BSplineInterpolation{T,N,typeof(parent),BSpline{D},typeof(axs)}(parent, axs, BSpline(degree))
     box_extrapolation(itp, args...)
 end
 
 function box_extrapolation(parent::AbstractArray{T,N}, degree::Interpolations.Degree, args...) where {T,N}
-    itp = interpolate(parent, BSpline(degree), OnGrid())
+    itp = interpolate(parent, BSpline(degree))
     box_extrapolation(itp, args...)
 end
 

--- a/src/resizing.jl
+++ b/src/resizing.jl
@@ -236,7 +236,7 @@ imresize_type(c) = typeof((c*1)/1)
 
 function imresize!(resized::AbstractArray{T,N}, original::AbstractArray{S,N}) where {T,S,N}
     # FIXME: avoid allocation for interpolation
-    itp = interpolate(original, BSpline(Linear()), OnGrid())
+    itp = interpolate(original, BSpline(Linear()))
     imresize!(resized, itp)
 end
 
@@ -257,12 +257,12 @@ function imresize!(resized::AbstractArray{T,N}, original::AbstractInterpolation{
     if all(x->x >= 1, sf)
         @inbounds for I in Rr
             I_o = map3((i,s,off)->s*i+off, I.I, sf, offset)
-            resized[I] = original[I_o...]
+            resized[I] = original(I_o...)
         end
     else
         @inbounds for I in Rr
             I_o = clampR(map3((i,s,off)->s*i+off, I.I, sf, offset), Ro)
-            resized[I] = original[I_o...]
+            resized[I] = original(I_o...)
         end
     end
     resized

--- a/test/interpolations.jl
+++ b/test/interpolations.jl
@@ -46,7 +46,7 @@ end
 
     etp = @inferred ImageTransformations.box_extrapolation(img)
     @test @inferred(ImageTransformations.box_extrapolation(etp)) === etp
-    @test_skip summary(etp) == "2×2 extrapolate(interpolate(::Array{Gray{N0f8},2}, BSpline(Linear()), OnGrid()), Gray{N0f8}(0.0)) with element type $(ctqual)Gray{$(fpqual)Normed{UInt8,8}}"
+    @test summary(etp) == "2×2 extrapolate(interpolate(::Array{Gray{N0f8},2}, BSpline(Linear())), Gray{N0f8}(0.0)) with element type $(ctqual)Gray{$(fpqual)Normed{UInt8,8}}"
     @test typeof(etp) <: Interpolations.FilledExtrapolation
     @test etp.fillvalue === Gray{N0f8}(0.0)
     @test etp.itp.coefs === img
@@ -64,48 +64,48 @@ end
     @test_throws ArgumentError ImageTransformations.box_extrapolation(etp.itp, Constant(), Flat())
 
     etp2 = @inferred ImageTransformations.box_extrapolation(etp.itp)
-    @test_skip summary(etp2) == "2×2 extrapolate(interpolate(::Array{Gray{N0f8},2}, BSpline(Linear()), OnGrid()), Gray{N0f8}(0.0)) with element type $(ctqual)Gray{$(fpqual)Normed{UInt8,8}}"
+    @test summary(etp2) == "2×2 extrapolate(interpolate(::Array{Gray{N0f8},2}, BSpline(Linear())), Gray{N0f8}(0.0)) with element type $(ctqual)Gray{$(fpqual)Normed{UInt8,8}}"
     @test typeof(etp2) <: Interpolations.FilledExtrapolation
     @test etp2.fillvalue === Gray{N0f8}(0.0)
     @test etp2 !== etp
     @test etp2.itp === etp.itp
 
     etp2 = @inferred ImageTransformations.box_extrapolation(etp.itp, Flat())
-    @test_skip summary(etp2) == "2×2 extrapolate(interpolate(::Array{Gray{N0f8},2}, BSpline(Linear()), OnGrid()), Flat()) with element type $(ctqual)Gray{$(fpqual)Normed{UInt8,8}}"
+    @test summary(etp2) == "2×2 extrapolate(interpolate(::Array{Gray{N0f8},2}, BSpline(Linear())), Flat()) with element type $(ctqual)Gray{$(fpqual)Normed{UInt8,8}}"
     @test typeof(etp2) <: Interpolations.Extrapolation
     @test etp2 !== etp
     @test etp2.itp === etp.itp
 
     etp = @inferred ImageTransformations.box_extrapolation(img, 1)
-    @test_skip summary(etp) == "2×2 extrapolate(interpolate(::Array{Gray{N0f8},2}, BSpline(Linear()), OnGrid()), Gray{N0f8}(1.0)) with element type $(ctqual)Gray{$(fpqual)Normed{UInt8,8}}"
+    @test summary(etp) == "2×2 extrapolate(interpolate(::Array{Gray{N0f8},2}, BSpline(Linear())), Gray{N0f8}(1.0)) with element type $(ctqual)Gray{$(fpqual)Normed{UInt8,8}}"
     @test typeof(etp) <: Interpolations.FilledExtrapolation
     @test etp.fillvalue === Gray{N0f8}(1.0)
     @test etp.itp.coefs === img
 
     etp = @inferred ImageTransformations.box_extrapolation(img, Flat())
     @test @inferred(ImageTransformations.box_extrapolation(etp)) === etp
-    @test_skip summary(etp) == "2×2 extrapolate(interpolate(::Array{Gray{N0f8},2}, BSpline(Linear()), OnGrid()), Flat()) with element type $(ctqual)Gray{$(fpqual)Normed{UInt8,8}}"
+    @test summary(etp) == "2×2 extrapolate(interpolate(::Array{Gray{N0f8},2}, BSpline(Linear())), Flat()) with element type $(ctqual)Gray{$(fpqual)Normed{UInt8,8}}"
     @test typeof(etp) <: Interpolations.Extrapolation
     @test etp.itp.coefs === img
 
     etp = @inferred ImageTransformations.box_extrapolation(img, Constant())
-    @test_skip summary(etp) == "2×2 extrapolate(interpolate(::Array{Gray{N0f8},2}, BSpline(Constant()), OnGrid()), Gray{N0f8}(0.0)) with element type $(ctqual)Gray{$(fpqual)Normed{UInt8,8}}"
+    @test summary(etp) == "2×2 extrapolate(interpolate(::Array{Gray{N0f8},2}, BSpline(Constant())), Gray{N0f8}(0.0)) with element type $(ctqual)Gray{$(fpqual)Normed{UInt8,8}}"
     @test typeof(etp) <: Interpolations.FilledExtrapolation
     @test etp.itp.coefs === img
 
     etp = @inferred ImageTransformations.box_extrapolation(img, Constant(), Flat())
-    @test_skip summary(etp) == "2×2 extrapolate(interpolate(::Array{Gray{N0f8},2}, BSpline(Constant()), OnGrid()), Flat()) with element type $(ctqual)Gray{$(fpqual)Normed{UInt8,8}}"
+    @test summary(etp) == "2×2 extrapolate(interpolate(::Array{Gray{N0f8},2}, BSpline(Constant())), Flat()) with element type $(ctqual)Gray{$(fpqual)Normed{UInt8,8}}"
     @test typeof(etp) <: Interpolations.Extrapolation
     @test etp.itp.coefs === img
 
     imgfloat = Float64.(img)
-    etp = @inferred ImageTransformations.box_extrapolation(imgfloat, Quadratic(Flat()))
+    etp = @inferred ImageTransformations.box_extrapolation(imgfloat, Quadratic(Flat(OnGrid())))
     @test typeof(etp) <: Interpolations.FilledExtrapolation
-    @test_skip summary(etp) == "2×2 extrapolate(interpolate(::Array{Float64,2}, BSpline(Quadratic(Flat())), OnGrid()), NaN) with element type Float64"
+    @test summary(etp) == "2×2 extrapolate(interpolate(OffsetArray(::Array{Float64,2}, 0:3, 0:3), BSpline(Quadratic(Flat(OnGrid())))), NaN) with element type Float64"
 
-    etp = @inferred ImageTransformations.box_extrapolation(imgfloat, Cubic(Flat()), Flat())
+    etp = @inferred ImageTransformations.box_extrapolation(imgfloat, Cubic(Flat(OnGrid())), Flat())
     @test typeof(etp) <: Interpolations.Extrapolation
-    @test_skip summary(etp) == "2×2 extrapolate(interpolate(::Array{Float64,2}, BSpline(Cubic(Flat())), OnGrid()), Flat()) with element type Float64"
+    @test summary(etp) == "2×2 extrapolate(interpolate(OffsetArray(::Array{Float64,2}, 0:3, 0:3), BSpline(Cubic(Flat(OnGrid())))), Flat()) with element type Float64"
 end
 
 @testset "AxisAlgorithms.A_ldiv_B_md" begin

--- a/test/warp.jl
+++ b/test/warp.jl
@@ -75,7 +75,7 @@ img_camera = testimage("camera")
     @testset "warpedview" begin
         imgr = @inferred(warpedview(img_camera, tfm))
         @test imgr == @inferred(WarpedView(img_camera, tfm))
-        @test_skip summary(imgr) == sumfmt("-78:591×-78:591","WarpedView(::Array{Gray{N0f8},2}, AffineMap([0.92388 -0.382683; 0.382683 0.92388], [117.683,$(SPACE)-78.6334])) with eltype $(ctqual)Gray{$(fpqual)Normed{UInt8,8}}")
+        @test summary(imgr) == sumfmt("-78:591×-78:591","WarpedView(::Array{Gray{N0f8},2}, AffineMap([0.92388 -0.382683; 0.382683 0.92388], [117.683,$(SPACE)-78.6334])) with eltype $(ctqual)Gray{$(fpqual)Normed{UInt8,8}}")
         @test @inferred(getindex(imgr,2,2)) == imgr[2,2]
         @test typeof(imgr[2,2]) == eltype(imgr)
         @test size(imgr) == ref_size
@@ -90,7 +90,7 @@ img_camera = testimage("camera")
 
         imgr = @inferred(warpedview(img_camera, tfm, axes(img_camera)))
         @test imgr == @inferred(WarpedView(img_camera, tfm, axes(img_camera)))
-        @test_skip summary(imgr) == "512×512 WarpedView(::Array{Gray{N0f8},2}, AffineMap([0.92388 -0.382683; 0.382683 0.92388], [117.683,$(SPACE)-78.6334])) with eltype $(ctqual)Gray{$(fpqual)Normed{UInt8,8}}"
+        @test summary(imgr) == "512×512 WarpedView(::Array{Gray{N0f8},2}, AffineMap([0.92388 -0.382683; 0.382683 0.92388], [117.683,$(SPACE)-78.6334])) with eltype $(ctqual)Gray{$(fpqual)Normed{UInt8,8}}"
         @test @inferred(size(imgr)) == size(img_camera)
         @test @inferred(size(imgr,3)) == 1
         @test parent(imgr) === img_camera
@@ -100,7 +100,7 @@ img_camera = testimage("camera")
         @test_reference "reference/warp_cameraman_rotate_r22deg_crop.txt" imgr
 
         imgr = @inferred(warpedview(img_camera, tfm, axes(img_camera), 1))
-        @test_skip summary(imgr) == "512×512 WarpedView(extrapolate(interpolate(::Array{Gray{N0f8},2}, BSpline(Linear()), OnGrid()), Gray{N0f8}(1.0)), AffineMap([0.92388 -0.382683; 0.382683 0.92388], [117.683,$(SPACE)-78.6334])) with eltype $(ctqual)Gray{$(fpqual)Normed{UInt8,8}}"
+        @test summary(imgr) == "512×512 WarpedView(extrapolate(interpolate(::Array{Gray{N0f8},2}, BSpline(Linear())), Gray{N0f8}(1.0)), AffineMap([0.92388 -0.382683; 0.382683 0.92388], [117.683,$(SPACE)-78.6334])) with eltype $(ctqual)Gray{$(fpqual)Normed{UInt8,8}}"
         @test @inferred(size(imgr)) == size(img_camera)
         @test @inferred(size(imgr,3)) == 1
         @test typeof(parent(imgr)) <: Interpolations.FilledExtrapolation
@@ -111,7 +111,7 @@ img_camera = testimage("camera")
         @test_reference "reference/warp_cameraman_rotate_r22deg_crop_white.txt" imgr
 
         imgr = @inferred(warpedview(img_camera, tfm, axes(img_camera), Linear(), 1))
-        @test_skip summary(imgr) == "512×512 WarpedView(extrapolate(interpolate(::Array{Gray{N0f8},2}, BSpline(Linear()), OnGrid()), Gray{N0f8}(1.0)), AffineMap([0.92388 -0.382683; 0.382683 0.92388], [117.683,$(SPACE)-78.6334])) with eltype $(ctqual)Gray{$(fpqual)Normed{UInt8,8}}"
+        @test summary(imgr) == "512×512 WarpedView(extrapolate(interpolate(::Array{Gray{N0f8},2}, BSpline(Linear())), Gray{N0f8}(1.0)), AffineMap([0.92388 -0.382683; 0.382683 0.92388], [117.683,$(SPACE)-78.6334])) with eltype $(ctqual)Gray{$(fpqual)Normed{UInt8,8}}"
         @test @inferred(size(imgr)) == size(img_camera)
         @test @inferred(size(imgr,3)) == 1
         @test typeof(parent(imgr)) <: Interpolations.FilledExtrapolation
@@ -122,7 +122,7 @@ img_camera = testimage("camera")
         @test_reference "reference/warp_cameraman_rotate_r22deg_crop_white.txt" imgr
 
         imgr = @inferred(warpedview(img_camera, tfm, 1))
-        @test_skip summary(imgr) == sumfmt("-78:591×-78:591","WarpedView(extrapolate(interpolate(::Array{Gray{N0f8},2}, BSpline(Linear()), OnGrid()), Gray{N0f8}(1.0)), AffineMap([0.92388 -0.382683; 0.382683 0.92388], [117.683,$(SPACE)-78.6334])) with eltype $(ctqual)Gray{$(fpqual)Normed{UInt8,8}}")
+        @test summary(imgr) == sumfmt("-78:591×-78:591","WarpedView(extrapolate(interpolate(::Array{Gray{N0f8},2}, BSpline(Linear())), Gray{N0f8}(1.0)), AffineMap([0.92388 -0.382683; 0.382683 0.92388], [117.683,$(SPACE)-78.6334])) with eltype $(ctqual)Gray{$(fpqual)Normed{UInt8,8}}")
         @test size(imgr) == ref_size
         @test typeof(parent(imgr)) <: Interpolations.FilledExtrapolation
         @test parent(imgr).itp.coefs === img_camera
@@ -136,7 +136,7 @@ img_camera = testimage("camera")
         # @test imgr2[axes(img_camera)...] ≈ img_camera
 
         imgr = @inferred(warpedview(img_camera, tfm, Flat()))
-        @test_skip summary(imgr) == sumfmt("-78:591×-78:591","WarpedView(extrapolate(interpolate(::Array{Gray{N0f8},2}, BSpline(Linear()), OnGrid()), Flat()), AffineMap([0.92388 -0.382683; 0.382683 0.92388], [117.683,$(SPACE)-78.6334])) with eltype $(ctqual)Gray{$(fpqual)Normed{UInt8,8}}")
+        @test summary(imgr) == sumfmt("-78:591×-78:591","WarpedView(extrapolate(interpolate(::Array{Gray{N0f8},2}, BSpline(Linear())), Flat()), AffineMap([0.92388 -0.382683; 0.382683 0.92388], [117.683,$(SPACE)-78.6334])) with eltype $(ctqual)Gray{$(fpqual)Normed{UInt8,8}}")
         @test size(imgr) == ref_size
         @test typeof(parent(imgr)) <: Interpolations.Extrapolation
         @test parent(imgr).itp.coefs === img_camera
@@ -149,7 +149,7 @@ img_camera = testimage("camera")
         @test_reference "reference/warp_cameraman_rotate_r22deg_flat.txt" imgr
 
         imgr = @inferred(warpedview(img_camera, tfm, Constant(), Periodic()))
-        @test_skip summary(imgr) == sumfmt("-78:591×-78:591","WarpedView(extrapolate(interpolate(::Array{Gray{N0f8},2}, BSpline(Constant()), OnGrid()), Periodic()), AffineMap([0.92388 -0.382683; 0.382683 0.92388], [117.683,$(SPACE)-78.6334])) with eltype $(ctqual)Gray{$(fpqual)Normed{UInt8,8}}")
+        @test summary(imgr) == sumfmt("-78:591×-78:591","WarpedView(extrapolate(interpolate(::Array{Gray{N0f8},2}, BSpline(Constant())), Periodic()), AffineMap([0.92388 -0.382683; 0.382683 0.92388], [117.683,$(SPACE)-78.6334])) with eltype $(ctqual)Gray{$(fpqual)Normed{UInt8,8}}")
         @test size(imgr) == ref_size
         @test typeof(parent(imgr)) <: Interpolations.Extrapolation
         @test parent(imgr).itp.coefs === img_camera
@@ -158,7 +158,7 @@ img_camera = testimage("camera")
         @test_reference "reference/warp_cameraman_rotate_r22deg_periodic.txt" imgr
 
         imgr = @inferred(warpedview(img_camera, tfm, ref_inds, Constant(), Periodic()))
-        @test_skip summary(imgr) == sumfmt("-78:591×-78:591","WarpedView(extrapolate(interpolate(::Array{Gray{N0f8},2}, BSpline(Constant()), OnGrid()), Periodic()), AffineMap([0.92388 -0.382683; 0.382683 0.92388], [117.683,$(SPACE)-78.6334])) with eltype $(ctqual)Gray{$(fpqual)Normed{UInt8,8}}")
+        @test summary(imgr) == sumfmt("-78:591×-78:591","WarpedView(extrapolate(interpolate(::Array{Gray{N0f8},2}, BSpline(Constant())), Periodic()), AffineMap([0.92388 -0.382683; 0.382683 0.92388], [117.683,$(SPACE)-78.6334])) with eltype $(ctqual)Gray{$(fpqual)Normed{UInt8,8}}")
         @test size(imgr) == ref_size
         @test eltype(imgr) == eltype(img_camera)
         @test_reference "reference/warp_cameraman_rotate_r22deg_periodic.txt" imgr
@@ -184,7 +184,7 @@ img_camera = testimage("camera")
 
         imgr = @inferred(invwarpedview(img_camera, tfm))
         @test imgr == @inferred(InvWarpedView(img_camera, tfm))
-        @test_skip summary(imgr) == sumfmt("-78:591×-78:591","InvWarpedView(::Array{Gray{N0f8},2}, AffineMap([0.92388 0.382683; -0.382683 0.92388], [-78.6334,$(SPACE)117.683])) with eltype $(ctqual)Gray{$(fpqual)Normed{UInt8,8}}")
+        @test summary(imgr) == sumfmt("-78:591×-78:591","InvWarpedView(::Array{Gray{N0f8},2}, AffineMap([0.92388 0.382683; -0.382683 0.92388], [-78.6334,$(SPACE)117.683])) with eltype $(ctqual)Gray{$(fpqual)Normed{UInt8,8}}")
         @test size(imgr) == ref_size
         @test parent(imgr) === img_camera
         @test typeof(imgr) <: InvWarpedView
@@ -197,7 +197,7 @@ img_camera = testimage("camera")
 
         imgr = @inferred(invwarpedview(img_camera, tfm, axes(img_camera)))
         @test imgr == @inferred(InvWarpedView(img_camera, tfm, axes(img_camera)))
-        @test_skip summary(imgr) == "512×512 InvWarpedView(::Array{Gray{N0f8},2}, AffineMap([0.92388 0.382683; -0.382683 0.92388], [-78.6334,$(SPACE)117.683])) with eltype $(ctqual)Gray{$(fpqual)Normed{UInt8,8}}"
+        @test summary(imgr) == "512×512 InvWarpedView(::Array{Gray{N0f8},2}, AffineMap([0.92388 0.382683; -0.382683 0.92388], [-78.6334,$(SPACE)117.683])) with eltype $(ctqual)Gray{$(fpqual)Normed{UInt8,8}}"
         @test @inferred(size(imgr)) == size(img_camera)
         @test @inferred(size(imgr,3)) == 1
         @test parent(imgr) === img_camera
@@ -207,7 +207,7 @@ img_camera = testimage("camera")
         @test_reference "reference/warp_cameraman_rotate_r22deg_crop.txt" imgr
 
         imgr = @inferred(invwarpedview(img_camera, tfm, axes(img_camera), 1))
-        @test_skip summary(imgr) == "512×512 InvWarpedView(extrapolate(interpolate(::Array{Gray{N0f8},2}, BSpline(Linear()), OnGrid()), Gray{N0f8}(1.0)), AffineMap([0.92388 0.382683; -0.382683 0.92388], [-78.6334,$(SPACE)117.683])) with eltype $(ctqual)Gray{$(fpqual)Normed{UInt8,8}}"
+        @test summary(imgr) == "512×512 InvWarpedView(extrapolate(interpolate(::Array{Gray{N0f8},2}, BSpline(Linear())), Gray{N0f8}(1.0)), AffineMap([0.92388 0.382683; -0.382683 0.92388], [-78.6334,$(SPACE)117.683])) with eltype $(ctqual)Gray{$(fpqual)Normed{UInt8,8}}"
         @test @inferred(size(imgr)) == size(img_camera)
         @test @inferred(size(imgr,3)) == 1
         @test typeof(parent(imgr)) <: Interpolations.FilledExtrapolation
@@ -218,7 +218,7 @@ img_camera = testimage("camera")
         @test_reference "reference/warp_cameraman_rotate_r22deg_crop_white.txt" imgr
 
         imgr = @inferred(invwarpedview(img_camera, tfm, axes(img_camera), Linear(), 1))
-        @test_skip summary(imgr) == "512×512 InvWarpedView(extrapolate(interpolate(::Array{Gray{N0f8},2}, BSpline(Linear()), OnGrid()), Gray{N0f8}(1.0)), AffineMap([0.92388 0.382683; -0.382683 0.92388], [-78.6334,$(SPACE)117.683])) with eltype $(ctqual)Gray{$(fpqual)Normed{UInt8,8}}"
+        @test summary(imgr) == "512×512 InvWarpedView(extrapolate(interpolate(::Array{Gray{N0f8},2}, BSpline(Linear())), Gray{N0f8}(1.0)), AffineMap([0.92388 0.382683; -0.382683 0.92388], [-78.6334,$(SPACE)117.683])) with eltype $(ctqual)Gray{$(fpqual)Normed{UInt8,8}}"
         @test @inferred(size(imgr)) == size(img_camera)
         @test @inferred(size(imgr,3)) == 1
         @test typeof(parent(imgr)) <: Interpolations.FilledExtrapolation
@@ -229,7 +229,7 @@ img_camera = testimage("camera")
         @test_reference "reference/warp_cameraman_rotate_r22deg_crop_white.txt" imgr
 
         imgr = @inferred(invwarpedview(img_camera, tfm, 1))
-        @test_skip summary(imgr) == sumfmt("-78:591×-78:591","InvWarpedView(extrapolate(interpolate(::Array{Gray{N0f8},2}, BSpline(Linear()), OnGrid()), Gray{N0f8}(1.0)), AffineMap([0.92388 0.382683; -0.382683 0.92388], [-78.6334,$(SPACE)117.683])) with eltype $(ctqual)Gray{$(fpqual)Normed{UInt8,8}}")
+        @test summary(imgr) == sumfmt("-78:591×-78:591","InvWarpedView(extrapolate(interpolate(::Array{Gray{N0f8},2}, BSpline(Linear())), Gray{N0f8}(1.0)), AffineMap([0.92388 0.382683; -0.382683 0.92388], [-78.6334,$(SPACE)117.683])) with eltype $(ctqual)Gray{$(fpqual)Normed{UInt8,8}}")
         @test size(imgr) == ref_size
         @test typeof(parent(imgr)) <: Interpolations.FilledExtrapolation
         @test parent(imgr).itp.coefs === img_camera
@@ -238,7 +238,7 @@ img_camera = testimage("camera")
         @test_reference "reference/warp_cameraman_rotate_r22deg_white.txt" imgr
 
         imgr = @inferred(invwarpedview(img_camera, tfm, Flat()))
-        @test_skip summary(imgr) == sumfmt("-78:591×-78:591","InvWarpedView(extrapolate(interpolate(::Array{Gray{N0f8},2}, BSpline(Linear()), OnGrid()), Flat()), AffineMap([0.92388 0.382683; -0.382683 0.92388], [-78.6334,$(SPACE)117.683])) with eltype $(ctqual)Gray{$(fpqual)Normed{UInt8,8}}")
+        @test summary(imgr) == sumfmt("-78:591×-78:591","InvWarpedView(extrapolate(interpolate(::Array{Gray{N0f8},2}, BSpline(Linear())), Flat()), AffineMap([0.92388 0.382683; -0.382683 0.92388], [-78.6334,$(SPACE)117.683])) with eltype $(ctqual)Gray{$(fpqual)Normed{UInt8,8}}")
         @test size(imgr) == ref_size
         @test typeof(parent(imgr)) <: Interpolations.Extrapolation
         @test parent(imgr).itp.coefs === img_camera
@@ -251,7 +251,7 @@ img_camera = testimage("camera")
         @test_reference "reference/warp_cameraman_rotate_r22deg_flat.txt" imgr
 
         imgr = @inferred(invwarpedview(img_camera, tfm, Constant(), Periodic()))
-        @test_skip summary(imgr) == sumfmt("-78:591×-78:591","InvWarpedView(extrapolate(interpolate(::Array{Gray{N0f8},2}, BSpline(Constant()), OnGrid()), Periodic()), AffineMap([0.92388 0.382683; -0.382683 0.92388], [-78.6334,$(SPACE)117.683])) with eltype $(ctqual)Gray{$(fpqual)Normed{UInt8,8}}")
+        @test summary(imgr) == sumfmt("-78:591×-78:591","InvWarpedView(extrapolate(interpolate(::Array{Gray{N0f8},2}, BSpline(Constant())), Periodic()), AffineMap([0.92388 0.382683; -0.382683 0.92388], [-78.6334,$(SPACE)117.683])) with eltype $(ctqual)Gray{$(fpqual)Normed{UInt8,8}}")
         @test size(imgr) == ref_size
         @test typeof(parent(imgr)) <: Interpolations.Extrapolation
         @test parent(imgr).itp.coefs === img_camera
@@ -260,7 +260,7 @@ img_camera = testimage("camera")
         @test_reference "reference/warp_cameraman_rotate_r22deg_periodic.txt" imgr
 
         imgr = @inferred(invwarpedview(img_camera, tfm, ref_inds, Constant(), Periodic()))
-        @test_skip summary(imgr) == sumfmt("-78:591×-78:591","InvWarpedView(extrapolate(interpolate(::Array{Gray{N0f8},2}, BSpline(Constant()), OnGrid()), Periodic()), AffineMap([0.92388 0.382683; -0.382683 0.92388], [-78.6334,$(SPACE)117.683])) with eltype $(ctqual)Gray{$(fpqual)Normed{UInt8,8}}")
+        @test summary(imgr) == sumfmt("-78:591×-78:591","InvWarpedView(extrapolate(interpolate(::Array{Gray{N0f8},2}, BSpline(Constant())), Periodic()), AffineMap([0.92388 0.382683; -0.382683 0.92388], [-78.6334,$(SPACE)117.683])) with eltype $(ctqual)Gray{$(fpqual)Normed{UInt8,8}}")
         @test size(imgr) == ref_size
         @test eltype(imgr) == eltype(img_camera)
         @test_reference "reference/warp_cameraman_rotate_r22deg_periodic.txt" imgr
@@ -271,7 +271,7 @@ img_camera = testimage("camera")
         wv = @inferred(InvWarpedView(img_camera, tfm))
         # tight crop that barely contains head and camera
         v = @inferred view(wv, 75:195, 245:370)
-        @test_skip summary(v) == "121×126 view(InvWarpedView(::Array{Gray{N0f8},2}, AffineMap([0.92388 0.382683; -0.382683 0.92388], [-78.6334,$(SPACE)117.683])), 75:195, 245:370) with eltype $(ctqual)Gray{$(fpqual)Normed{UInt8,8}}"
+        @test summary(v) == "121×126 view(InvWarpedView(::Array{Gray{N0f8},2}, AffineMap([0.92388 0.382683; -0.382683 0.92388], [-78.6334,$(SPACE)117.683])), 75:195, 245:370) with eltype $(ctqual)Gray{$(fpqual)Normed{UInt8,8}}"
         tfm2 = AffineMap(@SMatrix([0.6 0.;0. 0.8]), @SVector([10.,50.]))
         # this should still be a tight crop that
         # barely contains head and camera !
@@ -281,7 +281,7 @@ img_camera = testimage("camera")
         @test typeof(parent(wv2)) <: InvWarpedView
         @test typeof(parent(wv2)) <: InvWarpedView
         @test parent(parent(wv2)) === img_camera
-        @test_skip summary(wv2) == sumfmt("55:127×246:346","view(InvWarpedView(::Array{Gray{N0f8},2}, AffineMap([0.554328 0.22961; -0.306147 0.739104], [-37.18,$(SPACE)144.147])), IdentityRange(55:127), IdentityRange(246:346)) with eltype $(ctqual)Gray{$(fpqual)Normed{UInt8,8}}")
+        @test summary(wv2) == sumfmt("55:127×246:346","view(InvWarpedView(::Array{Gray{N0f8},2}, AffineMap([0.554328 0.22961; -0.306147 0.739104], [-37.18,$(SPACE)144.147])), IdentityRange(55:127), IdentityRange(246:346)) with eltype $(ctqual)Gray{$(fpqual)Normed{UInt8,8}}")
         @test_reference "reference/warp_cameraman_rotate_crop_scale.txt" wv2
         wv3 = @inferred invwarpedview(v, tfm2, wv2.indices)
         @test wv3 == wv2
@@ -292,7 +292,7 @@ img_camera = testimage("camera")
         tfm = recenter(RotMatrix(-pi/8), center(float_array))
         wv = @inferred(InvWarpedView(float_array, tfm))
         v = @inferred view(wv, 1:10, 1:10)
-        @test_skip summary(v) == "10×10 view(InvWarpedView(::Array{Float64,2}, AffineMap([0.92388 0.382683; -0.382683 0.92388], [-1.6861,$(SPACE)2.52342])), 1:10, 1:10) with eltype Float64"
+        @test summary(v) == "10×10 view(InvWarpedView(::Array{Float64,2}, AffineMap([0.92388 0.382683; -0.382683 0.92388], [-1.6861,$(SPACE)2.52342])), 1:10, 1:10) with eltype Float64"
     end
 end
 
@@ -355,12 +355,12 @@ ref_img_pyramid_grid = Float64[
         end
 
         @testset "Quadratic Interpolation" begin
-            itp = interpolate(img_pyramid_cntr, BSpline(Quadratic(Flat())), OnCell())
+            itp = interpolate(img_pyramid_cntr, BSpline(Quadratic(Flat(OnCell()))))
             imgrq_cntr = warp(itp, tfm2)
             @test axes(imgrq_cntr) == (-3:3, -3:3)
             @test nearlysame(round.(Float64.(parent(imgrq_cntr)), digits=3), round.(ref_img_pyramid_quad, digits=3))
 
-            imgrq_cntr = warp(img_pyramid_cntr, tfm2, Quadratic(Flat()))
+            imgrq_cntr = warp(img_pyramid_cntr, tfm2, Quadratic(Flat(OnGrid())))
             @test axes(imgrq_cntr) == (-3:3, -3:3)
             @test nearlysame(round.(Float64.(parent(imgrq_cntr)), digits=3), round.(ref_img_pyramid_grid, digits=3))
         end
@@ -379,10 +379,10 @@ ref_img_pyramid_grid = Float64[
         end
 
         @testset "Quadratic Interpolation" begin
-            itp = interpolate(img_pyramid_cntr, BSpline(Quadratic(Flat())), OnCell())
+            itp = interpolate(img_pyramid_cntr, BSpline(Quadratic(Flat(OnCell()))))
             imgrq_cntr = InvWarpedView(itp, inv(tfm2))
             @test parent(imgrq_cntr) === itp
-            @test_skip summary(imgrq_cntr) == sumfmt("-3:3×-3:3","InvWarpedView(interpolate(OffsetArray(::Array{Gray{Float64},2}, -2:4, -2:4), BSpline(Quadratic(Flat())), OnCell()), LinearMap([0.707107 0.707107; -0.707107 0.707107])) with eltype $(ctqual)Gray{Float64}")
+            @test summary(imgrq_cntr) == sumfmt("-3:3×-3:3","InvWarpedView(interpolate(OffsetArray(::Array{Gray{Float64},2}, -3:3, -3:3), BSpline(Quadratic(Flat(OnCell())))), LinearMap([0.707107 0.707107; -0.707107 0.707107])) with eltype $(ctqual)Gray{Float64}")
             @test axes(imgrq_cntr) == (-3:3, -3:3)
             @test nearlysame(round.(Float64.(imgrq_cntr[axes(imgrq_cntr)...]), digits=3), round.(ref_img_pyramid_quad, digits=3))
         end


### PR DESCRIPTION
The part of this I'm the least sure about is the Project.toml file. Should we be bumping the version number "pre-release" like this? It's also a bit unfortunate that I have those unbounded `≥ 0.2"` in the compat section (makes me think we want to transition to 1.x releases for packages sooner rather than later).