### PR TITLE
Better support for manually-constructed transformations

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -4,7 +4,7 @@ CoordinateTransformations 0.4.0
 Interpolations 0.9
 AxisAlgorithms
 OffsetArrays
-StaticArrays
+StaticArrays 0.10
 IdentityRanges
 ColorTypes
 Colors 0.7.0

--- a/src/ImageTransformations.jl
+++ b/src/ImageTransformations.jl
@@ -35,6 +35,8 @@ include("invwarpedview.jl")
 
 @inline _getindex(A, v::StaticVector) = A[Tuple(v)...]
 @inline _getindex(A::AbstractInterpolation, v::StaticVector) = A(Tuple(v)...)
+@inline _getindex(A, v) = A[v...]
+@inline _getindex(A::AbstractInterpolation, v) = A(v...)
 
 center(img::AbstractArray{T,N}) where {T,N} = SVector{N}(map(_center, axes(img)))
 _center(ind::AbstractUnitRange) = (first(ind)+last(ind))/2

--- a/src/autorange.jl
+++ b/src/autorange.jl
@@ -62,3 +62,15 @@ end
 # 0-d is special-cased to iterate once and only once
 Base.iterate(iter::CornerIterator{<:CartesianIndex{0}}) = (iter.start, nothing)
 Base.iterate(iter::CornerIterator{<:CartesianIndex{0}}, state) = nothing
+
+# Ensure that we use StaticArrays for linear transformations
+try_static(tfm, img) = tfm   # fallback
+try_static(tfm::AffineMap{<:SMatrix, <:SVector}, img::AbstractArray{T,N}) where {T,N} = tfm
+try_static(tfm::AffineMap{<:AbstractMatrix, <:AbstractVector}, img::AbstractArray{T,N}) where {T,N} =
+    AffineMap(SMatrix{N,N}(tfm.linear), SVector{N}(tfm.translation))
+try_static(tfm::LinearMap{<:SMatrix}, img::AbstractArray{T,N}) where {T,N} = tfm
+try_static(tfm::LinearMap{<:AbstractMatrix}, img::AbstractArray{T,N}) where {T,N} =
+    LinearMap(SMatrix{N,N}(tfm.linear))
+try_static(tfm::Translation{<:SVector}, img::AbstractArray{T,N}) where {T,N} = tfm
+try_static(tfm::Translation{<:AbstractVector}, img::AbstractArray{T,N}) where {T,N} =
+    Translation(SVector{N}(tfm.translation))

--- a/src/warp.jl
+++ b/src/warp.jl
@@ -81,7 +81,7 @@ julia> axes(imgr)
 """
 function warp(img::AbstractExtrapolation{T}, tform, inds::Tuple = autorange(img, inv(tform))) where T
     out = similar(Array{T}, inds)
-    warp!(out, img, tform)
+    warp!(out, img, try_static(tform, img))
 end
 
 function warp!(out, img::AbstractExtrapolation, tform)
@@ -93,12 +93,12 @@ end
 
 function warp(img::AbstractArray, tform, inds::Tuple, args...)
     etp = box_extrapolation(img, args...)
-    warp(etp, tform, inds)
+    warp(etp, try_static(tform, img), inds)
 end
 
 function warp(img::AbstractArray, tform, args...)
     etp = box_extrapolation(img, args...)
-    warp(etp, tform)
+    warp(etp, try_static(tform, img))
 end
 
 """

--- a/test/twoints.jl
+++ b/test/twoints.jl
@@ -1,0 +1,14 @@
+struct TwoInts
+    dim1::Int
+    dim2::Int
+end
+
+Base.length(::TwoInts) = 2
+Base.iterate(ti::TwoInts) = ti.dim1, false
+function Base.iterate(ti::TwoInts, isdone::Bool)
+    isdone && return nothing
+    return ti.dim2, true
+end
+
+Base.:(-)(ti::TwoInts) = TwoInts(-ti.dim1, -ti.dim2)
+Base.:(+)(v::SVector{2}, ti::TwoInts) = TwoInts(v[1] + ti.dim1, v[2] + ti.dim2)

--- a/test/warp.jl
+++ b/test/warp.jl
@@ -1,3 +1,6 @@
+using CoordinateTransformations, TestImages, ImageCore, Colors, FixedPointNumbers, StaticArrays, OffsetArrays, Interpolations, LinearAlgebra
+using Test, ReferenceTests
+
 # helper function to compare NaN
 nearlysame(x, y) = x ≈ y || (isnan(x) & isnan(y))
 nearlysame(A::AbstractArray, B::AbstractArray) = all(map(nearlysame, A, B))
@@ -13,6 +16,8 @@ ctqual = ""
 fpqual = ""
 
 sumfmt(ax,rest) = rest * " with indices " * ax
+
+include("twoints.jl")
 
 img_camera = testimage("camera")
 @testset "Interface tests" begin
@@ -80,6 +85,13 @@ img_camera = testimage("camera")
         tfmd = Translation([-2, 2])
         @test @inferred(warp(img_camera, tfmd)) == warp(img_camera, Translation(-2, 2))
         @test_throws DimensionMismatch("expected input array of length 2, got length 3") warp(img_camera, Translation([1,2,3]))
+
+        # Since Translation can be constructed from any iterable, check that we support this too.
+        # (This ensures the fallback for `_getindex` gets called even if we fix the issue by other means)
+        tfmt = Translation(TwoInts(1, 2))
+        @test tfmt isa Translation{TwoInts}
+        imgt = warp(img_camera, tfmt)  # not necessarily inferrable, that's OK
+        @test imgt == warp(img_camera, Translation(1,2))
     end
 
     @testset "warpedview" begin

--- a/test/warp.jl
+++ b/test/warp.jl
@@ -70,6 +70,16 @@ img_camera = testimage("camera")
         imgr = @inferred(warp(img_camera, tfm, ref_inds, Constant(), Periodic()))
         @test eltype(imgr) == eltype(img_camera)
         @test_reference "reference/warp_cameraman_rotate_r22deg_periodic.txt" imgr
+
+        # Ensure that dynamic arrays work as transformations
+        tfmd = AffineMap(Matrix(tfm.linear), Vector(tfm.translation))
+        imgrd = @inferred(warp(img_camera, tfmd))
+        @test imgrd == warp(img_camera, tfm)
+        tfmd = LinearMap(Matrix(tfm.linear))
+        @test @inferred(warp(img_camera, tfmd)) == warp(img_camera, LinearMap(tfm.linear))
+        tfmd = Translation([-2, 2])
+        @test @inferred(warp(img_camera, tfmd)) == warp(img_camera, Translation(-2, 2))
+        @test_throws DimensionMismatch("expected input array of length 2, got length 3") warp(img_camera, Translation([1,2,3]))
     end
 
     @testset "warpedview" begin


### PR DESCRIPTION
Motivated by https://discourse.julialang.org/t/rotate-a-image/17586. While that post has several errors, one thing that I noticed is that it's quite natural to assume you can construct your own transformation manually (you can), but that most users are likely to build them from `Array` rather than `SArray` types. And currently that has problems: with just the first commit here (adding tests but no fixes), I get this:

```julia
warp: Error During Test at /home/tim/.julia/dev/ImageTransformations/test/warp.jl:23
  Got exception outside of a @test
  MethodError: no method matching _getindex(::Interpolations.FilledExtrapolation{Gray{Normed{UInt8,8}},2,Interpolations.BSplineInterpolation{Gray{Normed{UInt8,8}},2,Array{Gray{Normed{UInt8,8}},2},BSpline{Linear},Tuple{Base.OneTo{Int64},Base.OneTo{Int64}}},BSpline{Linear},Gray{Normed{UInt8,8}}}, ::Array{Float64,1})
  Closest candidates are:
    _getindex(::AbstractInterpolation, !Matched::StaticArray{Tuple{N},T,1} where T where N) at /home/tim/.julia/dev/ImageTransformations/src/ImageTransformations.jl:37
    _getindex(::Any, !Matched::StaticArray{Tuple{N},T,1} where T where N) at /home/tim/.julia/dev/ImageTransformations/src/ImageTransformations.jl:36
  Stacktrace:
   [1] warp!(::OffsetArray{Gray{Normed{UInt8,8}},2,Array{Gray{Normed{UInt8,8}},2}}, ::Interpolations.FilledExtrapolation{Gray{Normed{UInt8,8}},2,Interpolations.BSplineInterpolation{Gray{Normed{UInt8,8}},2,Array{Gray{Normed{UInt8,8}},2},BSpline{Linear},Tuple{Base.OneTo{Int64},Base.OneTo{Int64}}},BSpline{Linear},Gray{Normed{UInt8,8}}}, ::AffineMap{Array{Float64,2},Array{Float64,1}}) at /home/tim/.julia/dev/ImageTransformations/src/warp.jl:89
   [2] warp(::Interpolations.FilledExtrapolation{Gray{Normed{UInt8,8}},2,Interpolations.BSplineInterpolation{Gray{Normed{UInt8,8}},2,Array{Gray{Normed{UInt8,8}},2},BSpline{Linear},Tuple{Base.OneTo{Int64},Base.OneTo{Int64}}},BSpline{Linear},Gray{Normed{UInt8,8}}}, ::AffineMap{Array{Float64,2},Array{Float64,1}}, ::Tuple{UnitRange{Int64},UnitRange{Int64}}) at /home/tim/.julia/dev/ImageTransformations/src/warp.jl:84
   [3] warp(::Interpolations.FilledExtrapolation{Gray{Normed{UInt8,8}},2,Interpolations.BSplineInterpolation{Gray{Normed{UInt8,8}},2,Array{Gray{Normed{UInt8,8}},2},BSpline{Linear},Tuple{Base.OneTo{Int64},Base.OneTo{Int64}}},BSpline{Linear},Gray{Normed{UInt8,8}}}, ::AffineMap{Array{Float64,2},Array{Float64,1}}) at /home/tim/.julia/dev/ImageTransformations/src/warp.jl:83
   [4] warp(::Array{Gray{Normed{UInt8,8}},2}, ::AffineMap{Array{Float64,2},Array{Float64,1}}) at /home/tim/.julia/dev/ImageTransformations/src/warp.jl:101
   [5] macro expansion at /home/tim/.julia/dev/ImageTransformations/test/warp.jl:76 [inlined]
...
```

If I include the 2nd commit, then I get this:

```julia
warp: Error During Test at /home/tim/.julia/dev/ImageTransformations/test/warp.jl:23
  Got exception outside of a @test
  return type OffsetArray{Gray{Normed{UInt8,8}},2,Array{Gray{Normed{UInt8,8}},2}} does not match inferred return type Any
  Stacktrace:
   [1] error(::String) at ./error.jl:33
   [2] macro expansion at /home/tim/.julia/dev/ImageTransformations/test/warp.jl:76 [inlined]
...
```

With all 3, they pass locally, although that requires https://github.com/JuliaArrays/StaticArrays.jl/pull/543. (If you prefer, we could be more vague about the specific error here.) 

Once we decide what to do about the error type, I have no objections to squashing these down to a single commit. It's just easier to verify necessity & sufficiency via Revise this way.