### PR TITLE
discretize transformation matrices for stable warp results

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -22,7 +22,7 @@ ImageCore = "0.8.1"
 Interpolations = "0.9, 0.10, 0.11, 0.12, 0.13"
 OffsetArrays = "0.10, 0.11, 1.0.1"
 Rotations = "0.12, 0.13, 1.0"
-StaticArrays = "0.10, 0.11, 0.12"
+StaticArrays = "0.10, 0.11, 0.12, 1.0"
 julia = "1"
 
 [extras]

--- a/src/warp.jl
+++ b/src/warp.jl
@@ -85,6 +85,7 @@ function warp(img::AbstractExtrapolation{T}, tform, inds::Tuple = autorange(img,
 end
 
 function warp!(out, img::AbstractExtrapolation, tform)
+    tform = _round(tform)
     @inbounds for I in CartesianIndices(axes(out))
         out[I] = _getindex(img, tform(SVector(I.I)))
     end

--- a/src/warpedview.jl
+++ b/src/warpedview.jl
@@ -26,7 +26,7 @@ struct WarpedView{T,N,A<:AbstractArray,F<:Transformation,I<:Tuple,E<:AbstractExt
             indices::I) where {T,N,TA<:AbstractArray,F<:Transformation,I<:Tuple}
         @assert eltype(parent) == T
         etp = box_extrapolation(parent)
-        new{T,N,TA,F,I,typeof(etp)}(parent, tform, indices, etp)
+        new{T,N,TA,F,I,typeof(etp)}(parent, _round(tform), indices, etp)
     end
 end
 


### PR DESCRIPTION
Unfortunately StaticArrays 1.0 breaks the tests with an insignificant numerical error, this patch stabilized it by introducing a discretization trick.

closes #104
closes #108 