### PR TITLE
Add `method` keyword for `imrotate`/`imresize`/`warp` to allow custom interpolation method

### DIFF
--- a/src/interpolations.jl
+++ b/src/interpolations.jl
@@ -4,6 +4,10 @@
 @inline _nan(::Type{HSV{Float64}}) = HSV{Float64}(NaN,NaN,NaN)
 @inline _nan(::Type{T}) where {T} = nan(T)
 
+#wraper to deal with degree or interpolation types
+@inline wrap_BSpline(itp::Interpolations.InterpolationType) = itp
+@inline wrap_BSpline(degree::Interpolations.Degree) = BSpline(degree)
+
 # The default values used by extrapolation for off-domain points
 const FillType = Union{Number,Colorant,Flat,Periodic,Reflect}
 const FloatLike{T<:AbstractFloat} = Union{T,AbstractGray{T}}

--- a/src/interpolations.jl
+++ b/src/interpolations.jl
@@ -61,6 +61,10 @@ function box_extrapolation(itp::AbstractExtrapolation, fill::FillType; kwargs...
     throw(ArgumentError("Boxing an extrapolation in another extrapolation is discouraged. Did you specify the parameter \"$fill\" on purpose?"))
 end
 
+function box_extrapolation(parent::AbstractArray, itp::Interpolations.InterpolationType; kwargs...)
+    throw(ArgumentError("Argument support for interpolation is not supported. Are you looking for the method keyword to pass an interpolation method?"))
+end
+
 # This is type-piracy, but necessary if we want Interpolations to be
 # independent of OffsetArrays.
 function AxisAlgorithms.A_ldiv_B_md!(dest::OffsetArray, F, src::OffsetArray, dim::Integer, b::AbstractVector)

--- a/src/interpolations.jl
+++ b/src/interpolations.jl
@@ -19,41 +19,45 @@ Interpolations.tweight(A::AbstractArray{C}) where C<:Colorant{T} where T = T
 
 box_extrapolation(etp::AbstractExtrapolation) = etp
 
-function box_extrapolation(itp::AbstractInterpolation{T}, fill::FillType = _default_fill(T)) where T
+function box_extrapolation(itp::AbstractInterpolation{T}, fill::FillType = _default_fill(T); kwargs...) where T
     etp = extrapolate(itp, _make_compatible(T, fill))
     box_extrapolation(etp)
 end
 
-function box_extrapolation(parent::AbstractArray, degree::D = Linear(), args...) where D<:Union{Linear,Constant}
+function box_extrapolation(parent::AbstractArray, args...; method::Union{Interpolations.Degree,Interpolations.InterpolationType}=Linear(), kwargs...)
+    if typeof(method)<:Interpolations.Degree
+        box_extrapolation(parent, method, args...)
+    else
+        itp = interpolate(parent, method)
+        box_extrapolation(itp, args...)
+    end
+end
+
+function box_extrapolation(parent::AbstractArray{T,N}, degree::Interpolations.Degree, args...; method::Union{Interpolations.Degree,Interpolations.InterpolationType}=Linear(), kwargs...) where {T,N}
+    itp = interpolate(parent, BSpline(degree))
+    box_extrapolation(itp, args...)
+end
+
+function box_extrapolation(parent::AbstractArray, degree::D, args...; method::Union{Interpolations.Degree,Interpolations.InterpolationType}=Linear(), kwargs...) where D<:Union{Linear,Constant}
     axs = axes(parent)
     T = typeof(zero(Interpolations.tweight(parent))*zero(eltype(parent)))
     itp = Interpolations.BSplineInterpolation{T,ndims(parent),typeof(parent),BSpline{D},typeof(axs)}(parent, axs, BSpline(degree))
     box_extrapolation(itp, args...)
 end
 
-function box_extrapolation(parent::AbstractArray{T,N}, degree::Interpolations.Degree, args...) where {T,N}
-    itp = interpolate(parent, BSpline(degree))
-    box_extrapolation(itp, args...)
-end
-
-function box_extrapolation(parent::AbstractArray{T,N}, aitp::Interpolations.AbstractLanczos, args...) where {T,N}
-    itp = interpolate(parent, aitp)
-    box_extrapolation(itp, args...)
-end
-
-function box_extrapolation(parent::AbstractArray, fill::FillType)
+function box_extrapolation(parent::AbstractArray, fill::FillType; kwargs...)
     box_extrapolation(parent, Linear(), fill)
 end
 
-function box_extrapolation(itp::AbstractInterpolation, degree::Union{Linear,Constant}, args...)
+function box_extrapolation(itp::AbstractInterpolation, degree::Union{Linear,Constant}, args...; kwargs...)
     throw(ArgumentError("Boxing an interpolation in another interpolation is discouraged. Did you specify the parameter \"$degree\" on purpose?"))
 end
 
-function box_extrapolation(itp::AbstractInterpolation, degree::Interpolations.Degree, args...)
+function box_extrapolation(itp::AbstractInterpolation, degree::Interpolations.Degree, args...; kwargs...)
     throw(ArgumentError("Boxing an interpolation in another interpolation is discouraged. Did you specify the parameter \"$degree\" on purpose?"))
 end
 
-function box_extrapolation(itp::AbstractExtrapolation, fill::FillType)
+function box_extrapolation(itp::AbstractExtrapolation, fill::FillType; kwargs...)
     throw(ArgumentError("Boxing an extrapolation in another extrapolation is discouraged. Did you specify the parameter \"$fill\" on purpose?"))
 end
 

--- a/src/interpolations.jl
+++ b/src/interpolations.jl
@@ -36,6 +36,11 @@ function box_extrapolation(parent::AbstractArray{T,N}, degree::Interpolations.De
     box_extrapolation(itp, args...)
 end
 
+function box_extrapolation(parent::AbstractArray{T,N}, aitp::Interpolations.Lanczos4OpenCV, args...) where {T,N}
+    itp = interpolate(parent, aitp)
+    box_extrapolation(itp, args...)
+end
+
 function box_extrapolation(parent::AbstractArray, fill::FillType)
     box_extrapolation(parent, Linear(), fill)
 end

--- a/src/interpolations.jl
+++ b/src/interpolations.jl
@@ -36,7 +36,7 @@ function box_extrapolation(parent::AbstractArray{T,N}, degree::Interpolations.De
     box_extrapolation(itp, args...)
 end
 
-function box_extrapolation(parent::AbstractArray{T,N}, aitp::Interpolations.Lanczos4OpenCV, args...) where {T,N}
+function box_extrapolation(parent::AbstractArray{T,N}, aitp::Interpolations.AbstractLanczos, args...) where {T,N}
     itp = interpolate(parent, aitp)
     box_extrapolation(itp, args...)
 end

--- a/src/resizing.jl
+++ b/src/resizing.jl
@@ -263,8 +263,9 @@ julia> imresize(img, (128, 128)) # 128*128
 julia> imresize(img, (1:128, 1:128)) # 128*128
 julia> imresize(img, (1:128, )) # 128*256
 julia> imresize(img, 128) # 128*256
-julia> imresize(img, ratio = 0.5) #
+julia> imresize(img, ratio = 0.5) #128*128
 julia> imresize(img, ratio = (2, 1)) # 256*128
+julia> imresize(img, (128,128), Lanczos4OpenCV()) #128*128
 
 σ = map((o,n)->0.75*o/n, size(img), sz)
 kern = KernelFactors.gaussian(σ)   # from ImageFiltering

--- a/src/resizing.jl
+++ b/src/resizing.jl
@@ -227,7 +227,7 @@ function restrict_indices(r::UnitRange)
 end
 
 # imresize
-imresize(original::AbstractArray, dim1::T, dimN::T...; kwargs...) where T<:Union{Integer,AbstractUnitRange} = imresize(original, (dim1,dimN...))
+imresize(original::AbstractArray, dim1::T, dimN::T...; kwargs...) where T<:Union{Integer,AbstractUnitRange} = imresize(original, (dim1,dimN...); kwargs...)
 function imresize(original::AbstractArray; ratio, kwargs...)
     all(ratio .> 0) || throw(ArgumentError("ratio $ratio should be positive"))
     new_size = ceil.(Int, size(original) .* ratio) # use ceil to avoid 0
@@ -239,6 +239,10 @@ function imresize(original::AbstractArray, short_size::Union{Indices{M},Dims{M}}
     len_short > ndims(original) && throw(DimensionMismatch("$short_size has too many dimensions for a $(ndims(original))-dimensional array"))
     new_size = ntuple(i -> (i > len_short ? odims(original, i, short_size) : short_size[i]), ndims(original))
     imresize(original, new_size; kwargs...)
+end
+
+function imresize(original::AbstractArray, itp::Union{Interpolations.Degree,Interpolations.InterpolationType}, args...; kwargs...)
+    throw(ArgumentError("Argument support for interpolation is not supported. Are you looking for the method keyword to pass an interpolation method?"))
 end
 
 odims(original, i, short_size::Tuple{Integer,Vararg{Integer}}) = size(original, i)

--- a/src/resizing.jl
+++ b/src/resizing.jl
@@ -242,7 +242,7 @@ function imresize(original::AbstractArray, short_size::Union{Indices{M},Dims{M}}
 end
 
 function imresize(original::AbstractArray, itp::Union{Interpolations.Degree,Interpolations.InterpolationType}, args...; kwargs...)
-    throw(ArgumentError("Argument support for interpolation is not supported. Are you looking for the method keyword to pass an interpolation method?"))
+    throw(ArgumentError("Positional parameter for interpolation method is not supported; use keyword `method` instead."))
 end
 
 odims(original, i, short_size::Tuple{Integer,Vararg{Integer}}) = size(original, i)
@@ -258,6 +258,10 @@ Change `img` to be of size `sz` (or to have indices `inds`). If `ratio` is used,
 `sz = ceil(Int, size(img).*ratio)`. This interpolates the values at sub-pixel locations.
 If you are shrinking the image, you risk aliasing unless you low-pass filter `img` first.
 
+The keyword `method` takes any InterpolationType from Interpolations.jl or a Degree,
+which is used to define a BSpline interpolation of that degree, in order to set
+the interpolation method used in the image resizing.
+
 # Examples
 ```julia
 julia> img = testimage("lena_gray_256") # 256*256
@@ -269,7 +273,9 @@ julia> imresize(img, (1:128, )) # 128*256
 julia> imresize(img, 128) # 128*256
 julia> imresize(img, ratio = 0.5) #128*128
 julia> imresize(img, ratio = (2, 1)) # 256*128
-julia> imresize(img, (128,128), Lanczos4OpenCV()) #128*128
+julia> imresize(img, (128,128), method=Linear()) #128*128
+julia> imresize(img, (128,128), method=BSpline(Linear())) #128*128
+julia> imresize(img, (128,128), method=Lanczos4OpenCV()) #128*128
 
 σ = map((o,n)->0.75*o/n, size(img), sz)
 kern = KernelFactors.gaussian(σ)   # from ImageFiltering
@@ -278,7 +284,7 @@ imgr = imresize(imfilter(img, kern, NA()), sz)
 
 See also [`restrict`](@ref).
 """
-function imresize(original::AbstractArray{T,0}, new_inds::Tuple{}) where T
+function imresize(original::AbstractArray{T,0}, new_inds::Tuple{}; kwargs...) where T
     Tnew = imresize_type(first(original))
     copyto!(similar(original, Tnew), original)
 end
@@ -317,9 +323,9 @@ imresize_type(c::Gray) = Gray{imresize_type(gray(c))}
 imresize_type(c::FixedPoint) = typeof(c)
 imresize_type(c) = typeof((c*1)/1)
 
-function imresize!(resized::AbstractArray{T,N}, original::AbstractArray{S,N}; method::Interpolations.InterpolationType=BSpline(Linear()), kwargs...) where {T,S,N}
+function imresize!(resized::AbstractArray{T,N}, original::AbstractArray{S,N}; method::Union{Interpolations.Degree,Interpolations.InterpolationType}=BSpline(Linear()), kwargs...) where {T,S,N}
     # FIXME: avoid allocation for interpolation
-    itp = interpolate(original, method)
+    itp = interpolate(original, wrap_BSpline(method))
     imresize!(resized, itp)
 end
 

--- a/src/resizing.jl
+++ b/src/resizing.jl
@@ -294,7 +294,7 @@ function imresize(original::AbstractArray{T,N}, new_size::Dims{N}) where {T,N}
     end
 end
 
-function imresize(original::AbstractArray{T,N}, new_size::Dims{N}, aitp::Interpolations.Lanczos4OpenCV) where {T,N}
+function imresize(original::AbstractArray{T,N}, new_size::Dims{N}, aitp::Interpolations.AbstractLanczos) where {T,N}
     Tnew = imresize_type(first(original))
     inds = axes(original)
     if map(length, inds) == new_size
@@ -334,7 +334,7 @@ function imresize!(resized::AbstractArray{T,N}, original::AbstractArray{S,N}) wh
     imresize!(resized, itp)
 end
 
-function imresize!(resized::AbstractArray{T,N}, original::AbstractArray{S,N}, aitp::Interpolations.Lanczos4OpenCV) where {T,S,N}
+function imresize!(resized::AbstractArray{T,N}, original::AbstractArray{S,N}, aitp::Interpolations.AbstractLanczos) where {T,S,N}
     # FIXME: avoid allocation for interpolation
     itp = interpolate(original, aitp)
     imresize!(resized, itp)

--- a/src/warp.jl
+++ b/src/warp.jl
@@ -92,13 +92,13 @@ function warp!(out, img::AbstractExtrapolation, tform)
     out
 end
 
-function warp(img::AbstractArray, tform, inds::Tuple, args...)
-    etp = box_extrapolation(img, args...)
+function warp(img::AbstractArray, tform, inds::Tuple, args...; kwargs...)
+    etp = box_extrapolation(img, args...; kwargs...)
     warp(etp, try_static(tform, img), inds)
 end
 
-function warp(img::AbstractArray, tform, args...)
-    etp = box_extrapolation(img, args...)
+function warp(img::AbstractArray, tform, args...; kwargs...)
+    etp = box_extrapolation(img, args...; kwargs...)
     warp(etp, try_static(tform, img))
 end
 
@@ -128,8 +128,8 @@ julia> imrotate(img, π/4, Constant())
 
 See also [`warp`](@ref).
 """
-function imrotate(img::AbstractArray{T}, θ::Real, args...) where T
+function imrotate(img::AbstractArray{T}, θ::Real, args...; kwargs...) where T
     θ = floor(mod(θ,2pi)*typemax(Int16))/typemax(Int16) # periodic discretezation
     tform = recenter(RotMatrix{2}(θ), center(img))
-    warp(img, tform, args...)
+    warp(img, tform, args...; kwargs...)
 end

--- a/src/warp.jl
+++ b/src/warp.jl
@@ -33,6 +33,10 @@ beyond-the-edge points are handled --- pass `img` as an
 `AbstractInterpolation` or `AbstractExtrapolation` from
 [Interpolations.jl](https://github.com/JuliaMath/Interpolations.jl).
 
+The keyword `method` now also takes any InterpolationType from Interpolations.jl
+or a Degree, which is used to define a BSpline interpolation of that degree, in
+order to set the interpolation method used.
+
 # The meaning of the coordinates
 
 The output array `imgw` has indices that would result from
@@ -122,8 +126,16 @@ julia> imrotate(img, π/4, axes(img))
 # rotate with nearest interpolation but without cropping
 julia> imrotate(img, π/4, Constant())
 
+The keyword `method` now also takes any InterpolationType from Interpolations.jl
+or a Degree, which is used to define a BSpline interpolation of that degree, in
+order to set the interpolation method used during image rotation.
+
+```julia
+# rotate with Linear interpolation without cropping
+julia> imrotate(img, π/4, method = Linear())
+
 # rotate with Lanczos4OpenCV interpolation without cropping
-julia> imrotate(img, π/4, Constant())
+julia> imrotate(img, π/4, method = Lanczos4OpenCV())
 ```
 
 See also [`warp`](@ref).

--- a/src/warp.jl
+++ b/src/warp.jl
@@ -113,13 +113,16 @@ By default, rotated image `imgr` will not be cropped. Bilinear interpolation wil
 ```julia
 julia> img = testimage("cameraman")
 
-# rotate with bilinear interpolation but without cropping 
+# rotate with bilinear interpolation but without cropping
 julia> imrotate(img, π/4)
 
 # rotate with bilinear interpolation and with cropping
 julia> imrotate(img, π/4, axes(img))
 
 # rotate with nearest interpolation but without cropping
+julia> imrotate(img, π/4, Constant())
+
+# rotate with Lanczos4OpenCV interpolation without cropping
 julia> imrotate(img, π/4, Constant())
 ```
 

--- a/test/interpolations.jl
+++ b/test/interpolations.jl
@@ -111,7 +111,7 @@ end
     @test typeof(etp) <: Interpolations.Extrapolation
     @test summary(etp) == "2×2 extrapolate(interpolate(OffsetArray(::$matrixf64_str, 0:3, 0:3), BSpline(Cubic(Flat(OnGrid())))), Flat()) with element type Float64"
 
-    etp = @inferred ImageTransformations.box_extrapolation(imgfloat, Lanczos4OpenCV())
+    etp = @inferred ImageTransformations.box_extrapolation(imgfloat, method=Lanczos4OpenCV())
     @test typeof(etp) <: Interpolations.FilledExtrapolation
 end
 

--- a/test/interpolations.jl
+++ b/test/interpolations.jl
@@ -113,6 +113,8 @@ end
 
     etp = @inferred ImageTransformations.box_extrapolation(imgfloat, method=Lanczos4OpenCV())
     @test typeof(etp) <: Interpolations.FilledExtrapolation
+
+    @test_throws ArgumentError ImageTransformations.box_extrapolation(imgfloat, BSpline(Linear()))
 end
 
 @testset "AxisAlgorithms.A_ldiv_B_md" begin

--- a/test/interpolations.jl
+++ b/test/interpolations.jl
@@ -110,6 +110,13 @@ end
     etp = @inferred ImageTransformations.box_extrapolation(imgfloat, Cubic(Flat(OnGrid())), Flat())
     @test typeof(etp) <: Interpolations.Extrapolation
     @test summary(etp) == "2×2 extrapolate(interpolate(OffsetArray(::$matrixf64_str, 0:3, 0:3), BSpline(Cubic(Flat(OnGrid())))), Flat()) with element type Float64"
+
+    etp = @inferred ImageTransformations.box_extrapolation(imgfloat, Lanczos4OpenCV())
+    summary(etp)
+    @test typeof(etp) <: Interpolations.FilledExtrapolation
+    @test summary(etp) == "2×2 extrapolate(::Interpolations.LanczosInterpolation{Float64,2,Lanczos4OpenCV,OffsetArray{Float64,2,Array{Float64,2}},Tuple{Base.OneTo{Int64},Base.OneTo{Int64}}}, NaN) with element type Float64"
+
+
 end
 
 @testset "AxisAlgorithms.A_ldiv_B_md" begin

--- a/test/interpolations.jl
+++ b/test/interpolations.jl
@@ -114,8 +114,7 @@ end
     etp = @inferred ImageTransformations.box_extrapolation(imgfloat, Lanczos4OpenCV())
     summary(etp)
     @test typeof(etp) <: Interpolations.FilledExtrapolation
-    @test summary(etp) == "2×2 extrapolate(::Interpolations.LanczosInterpolation{Float64,2,Lanczos4OpenCV,OffsetArray{Float64,2,Array{Float64,2}},Tuple{Base.OneTo{Int64},Base.OneTo{Int64}}}, NaN) with element type Float64"
-
+    @test summary(etp) == "2×2 extrapolate(::Interpolations.LanczosInterpolation{Float64,2,Lanczos4OpenCV,OffsetArray{Float64,2,::$matrixf64_str},Tuple{Base.OneTo{Int64},Base.OneTo{Int64}}}, NaN) with element type Float64"
 
 end
 

--- a/test/interpolations.jl
+++ b/test/interpolations.jl
@@ -112,10 +112,7 @@ end
     @test summary(etp) == "2×2 extrapolate(interpolate(OffsetArray(::$matrixf64_str, 0:3, 0:3), BSpline(Cubic(Flat(OnGrid())))), Flat()) with element type Float64"
 
     etp = @inferred ImageTransformations.box_extrapolation(imgfloat, Lanczos4OpenCV())
-    summary(etp)
     @test typeof(etp) <: Interpolations.FilledExtrapolation
-    @test summary(etp) == "2×2 extrapolate(::Interpolations.LanczosInterpolation{Float64,2,Lanczos4OpenCV,OffsetArray{Float64,2,::$matrixf64_str},Tuple{Base.OneTo{Int64},Base.OneTo{Int64}}}, NaN) with element type Float64"
-
 end
 
 @testset "AxisAlgorithms.A_ldiv_B_md" begin

--- a/test/resizing.jl
+++ b/test/resizing.jl
@@ -144,5 +144,15 @@ end
             @test ndims(R) == 0
             @test !(R === A)
         end
+
+    @testset "Interpolation" begin
+        img = rand(16,16)
+        etp = @inferred ImageTransformations.imresize(test_img,(128,128),Lanczos4OpenCV())
+        @test summary(etp) == "128×128 Array{Float64,2}"
+
+        etp = @inferred ImageTransformations.imresize(test_img,(16,16),Lanczos4OpenCV())
+        @test summary(etp) == "16×16 Array{Float64,2}"
+
+        end
     end
 end

--- a/test/resizing.jl
+++ b/test/resizing.jl
@@ -147,15 +147,11 @@ end
 
     @testset "Interpolation" begin
         img = rand(16,16)
-        out = ImageTransformations.imresize(img,(128,128),Lanczos4OpenCV())
+        out = ImageTransformations.imresize(img,(128,128),method=Lanczos4OpenCV())
         @test size(out) == (128,128)
 
-        out = ImageTransformations.imresize(img,(16,16),Lanczos4OpenCV())
+        out = ImageTransformations.imresize(img,(16,16),method=Lanczos4OpenCV())
         @test size(out) == (16,16)
-
-        img = rand(8,16)
-        out = ImageTransformations.imresize(img,(16,8),Lanczos4OpenCV())
-        @test size(out) == (16,8)
 
         end
     end

--- a/test/resizing.jl
+++ b/test/resizing.jl
@@ -147,11 +147,12 @@ end
 
     @testset "Interpolation" begin
         img = rand(16,16)
+        matrixf64_str = typestring(Matrix{Float64})
         etp = @inferred ImageTransformations.imresize(img,(128,128),Lanczos4OpenCV())
-        @test summary(etp) == "128×128 Array{Float64,2}"
+        @test summary(etp) == "128×128 ::$matrixf64_str"
 
         etp = @inferred ImageTransformations.imresize(img,(16,16),Lanczos4OpenCV())
-        @test summary(etp) == "16×16 Array{Float64,2}"
+        @test summary(etp) == "16×16 ::$matrixf64_str"
 
         end
     end

--- a/test/resizing.jl
+++ b/test/resizing.jl
@@ -147,12 +147,11 @@ end
 
     @testset "Interpolation" begin
         img = rand(16,16)
-        matrixf64_str = typestring(Matrix{Float64})
-        etp = @inferred ImageTransformations.imresize(img,(128,128),Lanczos4OpenCV())
-        @test summary(etp) == "128×128 ::$matrixf64_str"
+        out = ImageTransformations.imresize(img,(128,128),Lanczos4OpenCV())
+        @test size(out) == (128,128)
 
-        etp = @inferred ImageTransformations.imresize(img,(16,16),Lanczos4OpenCV())
-        @test summary(etp) == "16×16 ::$matrixf64_str"
+        out = ImageTransformations.imresize(img,(16,16),Lanczos4OpenCV())
+        @test size(out) == (16,16)
 
         end
     end

--- a/test/resizing.jl
+++ b/test/resizing.jl
@@ -153,6 +153,10 @@ end
         out = ImageTransformations.imresize(img,(16,16),Lanczos4OpenCV())
         @test size(out) == (16,16)
 
+        img = rand(8,16)
+        out = ImageTransformations.imresize(img,(16,8),Lanczos4OpenCV())
+        @test size(out) == (16,8)
+
         end
     end
 end

--- a/test/resizing.jl
+++ b/test/resizing.jl
@@ -153,6 +153,8 @@ end
         out = ImageTransformations.imresize(img,(16,16),method=Lanczos4OpenCV())
         @test size(out) == (16,16)
 
+        @test_throws ArgumentError imresize(img, BSpline(Linear()))
+        @test_throws ArgumentError imresize(img, Linear())
         end
     end
 end

--- a/test/resizing.jl
+++ b/test/resizing.jl
@@ -147,10 +147,10 @@ end
 
     @testset "Interpolation" begin
         img = rand(16,16)
-        etp = @inferred ImageTransformations.imresize(test_img,(128,128),Lanczos4OpenCV())
+        etp = @inferred ImageTransformations.imresize(img,(128,128),Lanczos4OpenCV())
         @test summary(etp) == "128×128 Array{Float64,2}"
 
-        etp = @inferred ImageTransformations.imresize(test_img,(16,16),Lanczos4OpenCV())
+        etp = @inferred ImageTransformations.imresize(img,(16,16),Lanczos4OpenCV())
         @test summary(etp) == "16×16 Array{Float64,2}"
 
         end

--- a/test/resizing.jl
+++ b/test/resizing.jl
@@ -87,7 +87,7 @@ end
             @test_throws ArgumentError imresize(img, ratio = -0.5)
             @test_throws ArgumentError imresize(img, ratio = (-0.5, 1))
             @test_throws DimensionMismatch imresize(img, ratio=(5,5,5))
-            @test_throws DimensionMismatch imresize(img,(5,5,1))
+            @test_throws DimensionMismatch imresize(img, (5,5,1))
         end
     end
 
@@ -147,17 +147,38 @@ end
 
     @testset "Interpolation" begin
         img = rand(16,16)
-        out = ImageTransformations.imresize(img,(128,128),method=Lanczos4OpenCV())
+        out = imresize(img, (128,128), method=Lanczos4OpenCV())
         @test size(out) == (128,128)
 
-        out = ImageTransformations.imresize(img,(128,128),method=Linear())
+        out = imresize(img, (128,128), method=Linear())
         @test size(out) == (128,128)
 
-        out = ImageTransformations.imresize(img,(16,16),method=Lanczos4OpenCV())
+        out = imresize(img, (16,16), method=Lanczos4OpenCV())
         @test size(out) == (16,16)
 
+        #test default behavior
+        @test imresize(img, (128,128)) == imresize(img, (128,128), method=Linear())
+
+        #check error handling
         @test_throws ArgumentError imresize(img, BSpline(Linear()))
         @test_throws ArgumentError imresize(img, Linear())
+
+        #consisency checks
+        @test imresize(img, (128, 128), method=Linear()) == imresize(OffsetArray(img, -1, -1), (128, 128), method=Linear())
+        @test imresize(img, (128, 128), method=BSpline(Linear())) == imresize(OffsetArray(img, -1, -1), (128, 128), method=BSpline(Linear()))
+        @test imresize(img, (128, 128), method=Lanczos4OpenCV()) == imresize(OffsetArray(img, -1, -1), (128, 128), method=Lanczos4OpenCV())
+
+        out = imresize(img, (0:127, 0:127), method=Linear())
+        @test axes(out) == (0:127, 0:127)
+        @test OffsetArrays.no_offset_view(out) == imresize(img, (128, 128), method=Linear())
+
+        out = imresize(img, (0:127, 0:127), method=BSpline(Linear()))
+        @test axes(out) == (0:127, 0:127)
+        @test OffsetArrays.no_offset_view(out) == imresize(img, (128, 128), method=BSpline(Linear()))
+
+        out = imresize(img, (0:127, 0:127), method=Lanczos4OpenCV())
+        @test axes(out) == (0:127, 0:127)
+        @test OffsetArrays.no_offset_view(out) == imresize(img, (128, 128), method=Lanczos4OpenCV())
         end
     end
 end

--- a/test/resizing.jl
+++ b/test/resizing.jl
@@ -150,6 +150,9 @@ end
         out = ImageTransformations.imresize(img,(128,128),method=Lanczos4OpenCV())
         @test size(out) == (128,128)
 
+        out = ImageTransformations.imresize(img,(128,128),method=Linear())
+        @test size(out) == (128,128)
+
         out = ImageTransformations.imresize(img,(16,16),method=Lanczos4OpenCV())
         @test size(out) == (16,16)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,7 +4,7 @@ using Test, ReferenceTests
 refambs = detect_ambiguities(CoordinateTransformations, Base, Core)
 using ImageTransformations
 ambs = detect_ambiguities(ImageTransformations, CoordinateTransformations, Base, Core)
-@test isempty(setdiff(ambs, refambs))
+#@test isempty(setdiff(ambs, refambs))
 
 function typestring(::Type{T}) where T   # from https://github.com/JuliaImages/ImageCore.jl/pull/133
     buf = IOBuffer()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,7 +4,7 @@ using Test, ReferenceTests
 refambs = detect_ambiguities(CoordinateTransformations, Base, Core)
 using ImageTransformations
 ambs = detect_ambiguities(ImageTransformations, CoordinateTransformations, Base, Core)
-#@test isempty(setdiff(ambs, refambs))
+@test isempty(setdiff(ambs, refambs))
 
 function typestring(::Type{T}) where T   # from https://github.com/JuliaImages/ImageCore.jl/pull/133
     buf = IOBuffer()


### PR DESCRIPTION
Fixes #111 

Added Lanczos4OpenCV support for both imrotate and imresize. Simply created methods which also take a Lanczos4OpenCV argument. Please advise if additions to test or documentation are desired.