### PR TITLE
ImageTransformations v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,54 @@
+# ImageTransformations
+
+## Version `v0.9.0`
+
+This version introduces changes internal `warp` and `invwarpedview` implementation thus users can expect some numerical differences. This version introduce a lot of API
+deprecations.
+
+- ![BREAKING][badge-breaking] Previously, `SubArray` passed to `invwarpedview` will use out-of-domain values to build a better result on the boundary. This is considered a too strong assumption and thus removed. ([#138][github-138])
+- ![BREAKING][badge-breaking] Rounding for numerical stability in `warp` is now applied to the corner points instead of to the transformation coefficients. ([#143][github-143])
+- ![Deprecation][badge-deprecation] `degree` and `fill` arguments are deprecated in favor of their keyword versions `method` and `fillvalue`. ([#116][github-116])
+- ![Deprecation][badge-deprecation] `invwarpedview` is deprecated in favor of `InvWarpedView`. ([#116][github-116], [#138][github-138])
+- ![Deprecation][badge-deprecation] `warpedview` is deprecated in favor of `WarpedView`. ([#116][github-116])
+- ![Enhancement][badge-enhancement] `restrict`/`restrict!` are moved to more lightweight package [ImageBase.jl]. ([#127][github-127])
+- ![Enhancement][badge-enhancement] `imresize` now works on transparent colorant types(e.g., `ARGB`). ([#126][github-126])
+- ![Enhancement][badge-enhancement] `restrict` now works on 0-argument colorant types(e.g., `ARGB32`). ([ImageBase#3][github-base-3])
+- ![Bugfix][badge-bugfix] Interpolations v0.13.3 compatibility. ([#132][github-132])
+- ![Bugfix][badge-bugfix] `restrict` on singleton dimension is now a no-op. ([ImageBase#8][github-base-8])
+- ![Bugfix][badge-bugfix] `restrict` on `OffsetArray` is now type stable. ([ImageBase#4][github-base-4])
+
+[github-143]: https://github.com/JuliaImages/ImageTransformations.jl/pull/143
+[github-138]: https://github.com/JuliaImages/ImageTransformations.jl/pull/138
+[github-132]: https://github.com/JuliaImages/ImageTransformations.jl/pull/132
+[github-127]: https://github.com/JuliaImages/ImageTransformations.jl/pull/127
+[github-126]: https://github.com/JuliaImages/ImageTransformations.jl/pull/126
+[github-116]: https://github.com/JuliaImages/ImageTransformations.jl/pull/116
+[github-base-8]: https://github.com/JuliaImages/ImageBase.jl/pull/8
+[github-base-4]: https://github.com/JuliaImages/ImageBase.jl/pull/4
+[github-base-3]: https://github.com/JuliaImages/ImageBase.jl/pull/3
+
+
+[ImageBase.jl]: https://github.com/JuliaImages/ImageBase.jl
+
+
+[badge-breaking]: https://img.shields.io/badge/BREAKING-red.svg
+[badge-deprecation]: https://img.shields.io/badge/deprecation-orange.svg
+[badge-feature]: https://img.shields.io/badge/feature-green.svg
+[badge-enhancement]: https://img.shields.io/badge/enhancement-blue.svg
+[badge-bugfix]: https://img.shields.io/badge/bugfix-purple.svg
+[badge-security]: https://img.shields.io/badge/security-black.svg
+[badge-experimental]: https://img.shields.io/badge/experimental-lightgrey.svg
+[badge-maintenance]: https://img.shields.io/badge/maintenance-gray.svg
+
+<!--
+# Badges
+
+![BREAKING][badge-breaking]
+![Deprecation][badge-deprecation]
+![Feature][badge-feature]
+![Enhancement][badge-enhancement]
+![Bugfix][badge-bugfix]
+![Security][badge-security]
+![Experimental][badge-experimental]
+![Maintenance][badge-maintenance]
+-->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,12 @@
 
 ## Version `v0.9.0`
 
-This version introduces changes internal `warp` and `invwarpedview` implementation thus users can expect some numerical differences. This version introduce a lot of API
-deprecations.
+This release contains numerous enhancements as well as quite a few deprecations. There are also
+internal changes that may cause small numerical differences from previous versions; these may be
+most obvious at the borders of the image, where decisions about inbounds/out-of-bounds can determine
+whether a "fill-value" is used instead of interpolation.
 
-- ![BREAKING][badge-breaking] Previously, `SubArray` passed to `invwarpedview` will use out-of-domain values to build a better result on the boundary. This is considered a too strong assumption and thus removed. ([#138][github-138])
+- ![BREAKING][badge-breaking] Previously, `SubArray` passed to `invwarpedview` will use out-of-domain values to build a better result on the border. This violated the array abstraction and has therefore been removed. ([#138][github-138])
 - ![BREAKING][badge-breaking] Rounding for numerical stability in `warp` is now applied to the corner points instead of to the transformation coefficients. ([#143][github-143])
 - ![Deprecation][badge-deprecation] `degree` and `fill` arguments are deprecated in favor of their keyword versions `method` and `fillvalue`. ([#116][github-116])
 - ![Deprecation][badge-deprecation] `invwarpedview` is deprecated in favor of `InvWarpedView`. ([#116][github-116], [#138][github-138])
@@ -13,9 +15,9 @@ deprecations.
 - ![Enhancement][badge-enhancement] `restrict`/`restrict!` are moved to more lightweight package [ImageBase.jl]. ([#127][github-127])
 - ![Enhancement][badge-enhancement] `imresize` now works on transparent colorant types(e.g., `ARGB`). ([#126][github-126])
 - ![Enhancement][badge-enhancement] `restrict` now works on 0-argument colorant types(e.g., `ARGB32`). ([ImageBase#3][github-base-3])
-- ![Bugfix][badge-bugfix] Interpolations v0.13.3 compatibility. ([#132][github-132])
+- ![Bugfix][badge-bugfix] Interpolations v0.13.3 compatibility (though 0.13.4 is now required). ([#132][github-132])
 - ![Bugfix][badge-bugfix] `restrict` on singleton dimension is now a no-op. ([ImageBase#8][github-base-8])
-- ![Bugfix][badge-bugfix] `restrict` on `OffsetArray` is now type stable. ([ImageBase#4][github-base-4])
+- ![Bugfix][badge-bugfix] `restrict` on `OffsetArray` always returns an `OffsetArray` result. ([ImageBase#4][github-base-4])
 
 [github-143]: https://github.com/JuliaImages/ImageTransformations.jl/pull/143
 [github-138]: https://github.com/JuliaImages/ImageTransformations.jl/pull/138

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ImageTransformations"
 uuid = "02fcd773-0e25-5acc-982a-7f6622650795"
-version = "0.8.12"
+version = "0.9.0"
 
 [deps]
 AxisAlgorithms = "13072b0f-2c55-5437-9ae7-d433b7a33950"

--- a/src/ImageTransformations.jl
+++ b/src/ImageTransformations.jl
@@ -8,10 +8,7 @@ using Interpolations, AxisAlgorithms
 using OffsetArrays
 using ColorVectorSpace
 
-import Base: eltype, size, length
 using Base: tail, Indices
-using Base.Cartesian
-using .ColorTypes: AbstractGray, TransparentGray, TransparentRGB
 
 # these two symbols previously live in ImageTransformations
 import ImageBase: restrict, restrict!

--- a/src/autorange.jl
+++ b/src/autorange.jl
@@ -54,12 +54,12 @@ struct CornerIterator{I<:CartesianIndex}
 end
 CornerIterator(R::CartesianIndices) = CornerIterator(first(R), last(R))
 
-eltype(::Type{CornerIterator{I}}) where {I} = I
+Base.eltype(::Type{CornerIterator{I}}) where {I} = I
 Base.Iterators.IteratorSize(::Type{CornerIterator{I}}) where {I<:CartesianIndex{N}} where {N} = Base.Iterators.HasShape{N}()
 
 # in 0.6 we could write: 1 .+ (iter.stop.I .- iter.start.I .!= 0)
-size(iter::CornerIterator{CartesianIndex{N}}) where {N} = ntuple(d->iter.stop.I[d]-iter.start.I[d]==0 ? 1 : 2, Val(N))::NTuple{N,Int}
-length(iter::CornerIterator) = prod(size(iter))
+Base.size(iter::CornerIterator{CartesianIndex{N}}) where {N} = ntuple(d->iter.stop.I[d]-iter.start.I[d]==0 ? 1 : 2, Val(N))::NTuple{N,Int}
+Base.length(iter::CornerIterator) = prod(size(iter))
 
 @inline function Base.iterate(iter::CornerIterator{<:CartesianIndex})
     if any(map(>, iter.start.I, iter.stop.I))

--- a/src/compat.jl
+++ b/src/compat.jl
@@ -6,8 +6,13 @@
     @inline isnothing(x) = x === nothing
 end
 
-# FIXME: upstream https://github.com/JuliaGraphics/ColorVectorSpace.jl/issues/75
-@inline _nan(::Type{HSV{Float16}}) = HSV{Float16}(NaN16,NaN16,NaN16)
-@inline _nan(::Type{HSV{Float32}}) = HSV{Float32}(NaN32,NaN32,NaN32)
-@inline _nan(::Type{HSV{Float64}}) = HSV{Float64}(NaN,NaN,NaN)
-@inline _nan(::Type{T}) where {T} = nan(T)
+if hasmethod(nan, Tuple{Type{HSV{Float32},}})
+    # requires ColorTypes v0.11 and ColorVectorSpace v0.9.4
+    # https://github.com/JuliaGraphics/ColorVectorSpace.jl/issues/75
+    @inline _nan(::Type{T}) where T = nan(T)
+else
+    @inline _nan(::Type{HSV{Float16}}) = HSV{Float16}(NaN16,NaN16,NaN16)
+    @inline _nan(::Type{HSV{Float32}}) = HSV{Float32}(NaN32,NaN32,NaN32)
+    @inline _nan(::Type{HSV{Float64}}) = HSV{Float64}(NaN,NaN,NaN)
+    @inline _nan(::Type{T}) where {T} = nan(T)
+end


### PR DESCRIPTION
Here's my plan for the next minor release:

Todo:

- [x] documentation CI (moving https://juliaimages.org/stable/pkgs/transformations/ here) (#131)
- [x] revisit #68 (close or fix it)
- [x] deprecate `invwarpedview` in favor of `InvWarpedView` (#138)
- [x] remove all `summary` test in favor of `eltype`/`typeof`/`size`/`axes`... (#136)
- [ ] fixed point perspective for imresize, zoom and imrotate (#142)
- [x] Restrict rounding to the computed corners (#143)

bugs:

- [x] new type instability during restrict on OffsetArray (#118)
- [x] imresize failed with ARGB32 (#97)
- [x] restrict produces wrong boundary values if called with a one-row array (#47)

maintenance:

- [x] upgrade legacy methods with cleaner keyword alternative (#116) -- API deprecations
- [x] Move restrict to a faster loading package (#69)

enhancements:

- [x] skip prefilter for Linear and Constant (#125)
- [ ] `imresize`/`imrotate` fixed point (#121)

---

The test failure is due to version locks on test dependency, no need to worry about.