### PR TITLE
skip prefilter for Linear and Constant

### DIFF
--- a/src/compat.jl
+++ b/src/compat.jl
@@ -25,7 +25,10 @@ end
 @inline _nan(::Type{T}) where {T} = nan(T)
 
 if !hasmethod(Constant{Nearest}, ())
-    # compat for Interpolations <= v0.13.2
+    # `Constant{Nearest}()` is not defined for Interpolations <= v0.13.2
     # https://github.com/JuliaMath/Interpolations.jl/pull/426
-    Interpolations.Constant{Nearest}() = Constant()
+    construct_interpolation_type(::Type{T}) where T<:Union{Linear, Constant} = T()
+    construct_interpolation_type(::Type{Constant{Nearest}}) = Constant()
+else
+    construct_interpolation_type(::Type{T}) where T<:Union{Linear, Constant} = T()
 end

--- a/src/compat.jl
+++ b/src/compat.jl
@@ -23,3 +23,9 @@ end
 @inline _nan(::Type{HSV{Float32}}) = HSV{Float32}(NaN32,NaN32,NaN32)
 @inline _nan(::Type{HSV{Float64}}) = HSV{Float64}(NaN,NaN,NaN)
 @inline _nan(::Type{T}) where {T} = nan(T)
+
+if !hasmethod(Constant{Nearest}, ())
+    # compat for Interpolations <= v0.13.2
+    # https://github.com/JuliaMath/Interpolations.jl/pull/426
+    Interpolations.Constant{Nearest}() = Constant()
+end

--- a/src/interpolations.jl
+++ b/src/interpolations.jl
@@ -23,19 +23,22 @@ function box_extrapolation(
         method=Linear(),
         kwargs...)
     T = typeof(zero(Interpolations.tweight(parent)) * zero(eltype(parent)))
-    itp = maybe_lazy_interpolate(T, parent, method)
+    itp = maybe_skip_prefilter(T, parent, method)
     extrapolate(itp, _make_compatible(T, fillvalue))
 end
 box_extrapolation(etp::AbstractExtrapolation) = etp
 box_extrapolation(itp::AbstractInterpolation{T}; fillvalue=_default_fillvalue(T)) where T =
     extrapolate(itp, _make_compatible(T, fillvalue))
 
-@inline function maybe_lazy_interpolate(::Type{T}, A::AbstractArray, degree::D) where {T, D<:Union{Linear, Constant}}
+@inline function maybe_skip_prefilter(::Type{T}, A::AbstractArray, degree::D) where {T, D<:Union{Linear, Constant}}
     axs = axes(A)
     return Interpolations.BSplineInterpolation{T,ndims(A),typeof(A),BSpline{D},typeof(axs)}(A, axs, BSpline(degree))
 end
+@inline function maybe_skip_prefilter(::Type{T}, A::AbstractArray, method::BSpline{D}) where {T, D<:Union{Linear, Constant}}
+    maybe_skip_prefilter(T, A, D())
+end
 
-@inline function maybe_lazy_interpolate(::Type{T}, A::AbstractArray, method::MethodType) where T
+@inline function maybe_skip_prefilter(::Type{T}, A::AbstractArray, method::MethodType) where T
     return interpolate(A, wrap_BSpline(method))
 end
 

--- a/src/interpolations.jl
+++ b/src/interpolations.jl
@@ -35,7 +35,7 @@ box_extrapolation(itp::AbstractInterpolation{T}; fillvalue=_default_fillvalue(T)
     return Interpolations.BSplineInterpolation{T,ndims(A),typeof(A),BSpline{D},typeof(axs)}(A, axs, BSpline(degree))
 end
 @inline function maybe_skip_prefilter(::Type{T}, A::AbstractArray, method::BSpline{D}) where {T, D<:Union{Linear, Constant}}
-    maybe_skip_prefilter(T, A, D())
+    maybe_skip_prefilter(T, A, construct_interpolation_type(D))
 end
 
 @inline function maybe_skip_prefilter(::Type{T}, A::AbstractArray, method::MethodType) where T

--- a/test/interpolations.jl
+++ b/test/interpolations.jl
@@ -46,16 +46,19 @@ end
     n0f8_str = typestring(N0f8)
     matrixf64_str = typestring(Matrix{Float64})
 
-    etp = @inferred ImageTransformations.box_extrapolation(img)
-    @test @inferred(ImageTransformations.box_extrapolation(etp)) === etp
-    @test summary(etp) == "2×2 extrapolate(interpolate(::Array{Gray{N0f8},2}, BSpline(Linear())), Gray{N0f8}(0.0)) with element type $(ctqual)Gray{$(fpqual)$n0f8_str}"
-    @test typeof(etp) <: Interpolations.FilledExtrapolation
-    @test etp.fillvalue === Gray{N0f8}(0.0)
-    @test etp.itp.coefs === img
+    for method in (Linear(), BSpline(Linear()), Constant(), BSpline(Constant()))
+        etp = @inferred ImageTransformations.box_extrapolation(img, method=method)
+        @test @inferred(ImageTransformations.box_extrapolation(etp)) === etp
+        # @test summary(etp) == "2×2 extrapolate(interpolate(::Array{Gray{N0f8},2}, BSpline(Linear())), Gray{N0f8}(0.0)) with element type $(ctqual)Gray{$(fpqual)$n0f8_str}"
+        @test typeof(etp) <: Interpolations.FilledExtrapolation
+        @test etp.fillvalue === Gray{N0f8}(0.0)
+        @test etp.itp.coefs === img
+    end
 
     # to catch regressions like #60
     @test @inferred(ImageTransformations._getindex(img, @SVector([1,2]))) isa Gray{N0f8}
 
+    etp = @inferred ImageTransformations.box_extrapolation(img)
     etp2 = @inferred ImageTransformations.box_extrapolation(etp.itp)
     @test summary(etp2) == "2×2 extrapolate(interpolate(::Array{Gray{N0f8},2}, BSpline(Linear())), Gray{N0f8}(0.0)) with element type $(ctqual)Gray{$(fpqual)$n0f8_str}"
     @test typeof(etp2) <: Interpolations.FilledExtrapolation
@@ -63,6 +66,7 @@ end
     @test etp2 !== etp
     @test etp2.itp === etp.itp
 
+    etp = @inferred ImageTransformations.box_extrapolation(img)
     etp2 = @inferred ImageTransformations.box_extrapolation(etp.itp, fillvalue=Flat())
     @test summary(etp2) == "2×2 extrapolate(interpolate(::Array{Gray{N0f8},2}, BSpline(Linear())), Flat()) with element type $(ctqual)Gray{$(fpqual)$n0f8_str}"
     @test typeof(etp2) <: Interpolations.Extrapolation


### PR DESCRIPTION
Now that `Linear()` is just equivalent to `BSpline(Linear())`:

```julia
using ImageTransformations, ImageCore, ImageShow, TestImages, Interpolations
img = testimage("cameraman");

@btime imrotate($img, 0.3; method=Linear()); # 3.557 ms (21 allocations: 403.88 KiB)
@btime imrotate($img, 0.3; method=BSpline(Linear()));
# master: 3.491 ms (23 allocations: 660.02 KiB)
# PR: 3.639 ms (21 allocations: 403.88 KiB)
```

cc: @andrew-saydjari