### PR TITLE
use method.degree instead of constructing a new one

### DIFF
--- a/src/compat.jl
+++ b/src/compat.jl
@@ -23,12 +23,3 @@ end
 @inline _nan(::Type{HSV{Float32}}) = HSV{Float32}(NaN32,NaN32,NaN32)
 @inline _nan(::Type{HSV{Float64}}) = HSV{Float64}(NaN,NaN,NaN)
 @inline _nan(::Type{T}) where {T} = nan(T)
-
-if !hasmethod(Constant{Nearest}, ())
-    # `Constant{Nearest}()` is not defined for Interpolations <= v0.13.2
-    # https://github.com/JuliaMath/Interpolations.jl/pull/426
-    construct_interpolation_type(::Type{T}) where T<:Union{Linear, Constant} = T()
-    construct_interpolation_type(::Type{Constant{Nearest}}) = Constant()
-else
-    construct_interpolation_type(::Type{T}) where T<:Union{Linear, Constant} = T()
-end

--- a/src/interpolations.jl
+++ b/src/interpolations.jl
@@ -35,7 +35,7 @@ box_extrapolation(itp::AbstractInterpolation{T}; fillvalue=_default_fillvalue(T)
     return Interpolations.BSplineInterpolation{T,ndims(A),typeof(A),BSpline{D},typeof(axs)}(A, axs, BSpline(degree))
 end
 @inline function maybe_skip_prefilter(::Type{T}, A::AbstractArray, method::BSpline{D}) where {T, D<:Union{Linear, Constant}}
-    maybe_skip_prefilter(T, A, construct_interpolation_type(D))
+    maybe_skip_prefilter(T, A, method.degree)
 end
 
 @inline function maybe_skip_prefilter(::Type{T}, A::AbstractArray, method::MethodType) where T


### PR DESCRIPTION
Unfortunately, the previous compat patch doesn't work very well in Interpolations v0.13.3 https://github.com/JuliaMath/Interpolations.jl/pull/442

This PR directly uses `method.degree` so as to avoid the construction of it.