### PR TITLE
dependency version clean up

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,8 +14,8 @@ Rotations = "6038ab10-8711-5258-84ad-4b1120ba62dc"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
-AxisAlgorithms = "1.0"
-ColorVectorSpace = "0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9"
+AxisAlgorithms = "0.3, 1.0"
+ColorVectorSpace = "0.6, 0.7, 0.8, 0.9"
 CoordinateTransformations = "0.5, 0.6"
 ImageBase = "0.1.1"
 ImageCore = "0.8.1, 0.9"


### PR DESCRIPTION
- AxisAlgorithm v0.3 is added to support old Interpolation versions < v0.12
- ColorVectorSpace < 0.6 is acient releases for Julia < 1.0. There is no need
  to still keep them in compat list

I've manually tested that CVS v0.6 and Interpolations v0.9 are compatible, i.e., passing the tests.