### PR TITLE
remove all summary test

### DIFF
--- a/test/interpolations.jl
+++ b/test/interpolations.jl
@@ -1,8 +1,3 @@
-#ctqual = "ColorTypes."
-ctqual = ""
-# fpqual = "FixedPointNumbers."
-fpqual = ""
-
 @testset "_default_fillvalue" begin
     @test_throws UndefVarError _default_fillvalue
     @test typeof(ImageTransformations._default_fillvalue) <: Function
@@ -43,14 +38,14 @@ end
     @test typeof(ImageTransformations.box_extrapolation) <: Function
 
     img = rand(Gray{N0f8}, 2, 2)
-    n0f8_str = typestring(N0f8)
-    matrixf64_str = typestring(Matrix{Float64})
 
     for method in (Linear(), BSpline(Linear()), Constant(), BSpline(Constant()))
         etp = @inferred ImageTransformations.box_extrapolation(img, method=method)
         @test @inferred(ImageTransformations.box_extrapolation(etp)) === etp
-        # @test summary(etp) == "2×2 extrapolate(interpolate(::Array{Gray{N0f8},2}, BSpline(Linear())), Gray{N0f8}(0.0)) with element type $(ctqual)Gray{$(fpqual)$n0f8_str}"
-        @test typeof(etp) <: Interpolations.FilledExtrapolation
+        @test size(etp) == size(img)
+        @test eltype(etp) == eltype(img)
+        @test etp.itp isa Interpolations.BSplineInterpolation
+        @test etp isa Interpolations.FilledExtrapolation
         @test etp.fillvalue === Gray{N0f8}(0.0)
         @test etp.itp.coefs === img
     end
@@ -60,54 +55,74 @@ end
 
     etp = @inferred ImageTransformations.box_extrapolation(img)
     etp2 = @inferred ImageTransformations.box_extrapolation(etp.itp)
-    @test summary(etp2) == "2×2 extrapolate(interpolate(::Array{Gray{N0f8},2}, BSpline(Linear())), Gray{N0f8}(0.0)) with element type $(ctqual)Gray{$(fpqual)$n0f8_str}"
-    @test typeof(etp2) <: Interpolations.FilledExtrapolation
+    @test size(etp) == size(img)
+    @test eltype(etp) == eltype(img)
+    @test etp.itp isa Interpolations.BSplineInterpolation
+    @test etp2 isa Interpolations.FilledExtrapolation
     @test etp2.fillvalue === Gray{N0f8}(0.0)
     @test etp2 !== etp
     @test etp2.itp === etp.itp
 
     etp = @inferred ImageTransformations.box_extrapolation(img)
     etp2 = @inferred ImageTransformations.box_extrapolation(etp.itp, fillvalue=Flat())
-    @test summary(etp2) == "2×2 extrapolate(interpolate(::Array{Gray{N0f8},2}, BSpline(Linear())), Flat()) with element type $(ctqual)Gray{$(fpqual)$n0f8_str}"
-    @test typeof(etp2) <: Interpolations.Extrapolation
+    @test size(etp2) == size(img)
+    @test eltype(etp2) == eltype(img)
+    @test etp2.itp isa Interpolations.BSplineInterpolation
+    @test etp2 isa Interpolations.Extrapolation
+    @test etp2.et == Flat()
     @test etp2 !== etp
     @test etp2.itp === etp.itp
 
     etp = @inferred ImageTransformations.box_extrapolation(img, fillvalue=1)
-    @test summary(etp) == "2×2 extrapolate(interpolate(::Array{Gray{N0f8},2}, BSpline(Linear())), Gray{N0f8}(1.0)) with element type $(ctqual)Gray{$(fpqual)$n0f8_str}"
-    @test typeof(etp) <: Interpolations.FilledExtrapolation
+    @test size(etp) == size(img)
+    @test eltype(etp) == eltype(img)
+    @test etp.itp isa Interpolations.BSplineInterpolation
+    @test etp isa Interpolations.FilledExtrapolation
     @test etp.fillvalue === Gray{N0f8}(1.0)
     @test etp.itp.coefs === img
 
     etp = @inferred ImageTransformations.box_extrapolation(img, fillvalue=Flat())
     @test @inferred(ImageTransformations.box_extrapolation(etp)) === etp
-    @test summary(etp) == "2×2 extrapolate(interpolate(::Array{Gray{N0f8},2}, BSpline(Linear())), Flat()) with element type $(ctqual)Gray{$(fpqual)$n0f8_str}"
-    @test typeof(etp) <: Interpolations.Extrapolation
+    @test size(etp) == size(img)
+    @test eltype(etp) == eltype(img)
+    @test etp.itp isa Interpolations.BSplineInterpolation
+    @test etp isa Interpolations.Extrapolation
+    @test etp.et == Flat()
     @test etp.itp.coefs === img
 
     etp = @inferred ImageTransformations.box_extrapolation(img, method=Constant())
-    str = summary(etp)
-    @test occursin("2×2 extrapolate(interpolate(::Array{Gray{N0f8},2}, BSpline(Constant", str) && occursin("Gray{N0f8}(0.0)) with element type $(ctqual)Gray{$(fpqual)$n0f8_str}", str)
-    @test typeof(etp) <: Interpolations.FilledExtrapolation
+    @test size(etp) == size(img)
+    @test eltype(etp) == eltype(img)
+    @test etp.itp.it == BSpline(Constant{Nearest}())
+    @test etp isa Interpolations.FilledExtrapolation
     @test etp.itp.coefs === img
 
     etp = @inferred ImageTransformations.box_extrapolation(img, method=Constant(), fillvalue=Flat())
-    str = summary(etp)
-    @test occursin("2×2 extrapolate(interpolate(::Array{Gray{N0f8},2}, BSpline(Constant", str) && occursin("Flat()) with element type $(ctqual)Gray{$(fpqual)$n0f8_str}", str)
-    @test typeof(etp) <: Interpolations.Extrapolation
+    @test size(etp) == size(img)
+    @test eltype(etp) == eltype(img)
+    @test etp.itp.it == BSpline(Constant{Nearest}())
+    @test etp isa Interpolations.Extrapolation
+    @test etp.et == Flat()
     @test etp.itp.coefs === img
 
     imgfloat = Float64.(img)
     etp = @inferred ImageTransformations.box_extrapolation(imgfloat, method=Quadratic(Flat(OnGrid())))
-    @test typeof(etp) <: Interpolations.FilledExtrapolation
-    @test summary(etp) == "2×2 extrapolate(interpolate(OffsetArray(::$matrixf64_str, 0:3, 0:3), BSpline(Quadratic(Flat(OnGrid())))), NaN) with element type Float64"
+    @test size(etp) == size(imgfloat)
+    @test eltype(etp) == eltype(imgfloat)
+    @test etp.itp.it == BSpline(Quadratic(Flat(OnGrid())))
+    @test etp isa Interpolations.FilledExtrapolation
 
     etp = @inferred ImageTransformations.box_extrapolation(imgfloat, method=Cubic(Flat(OnGrid())), fillvalue=Flat())
-    @test typeof(etp) <: Interpolations.Extrapolation
-    @test summary(etp) == "2×2 extrapolate(interpolate(OffsetArray(::$matrixf64_str, 0:3, 0:3), BSpline(Cubic(Flat(OnGrid())))), Flat()) with element type Float64"
+    @test size(etp) == size(imgfloat)
+    @test eltype(etp) == eltype(imgfloat)
+    @test etp.itp.it == BSpline(Cubic(Flat(OnGrid())))
+    @test etp isa Interpolations.Extrapolation
 
     etp = @inferred ImageTransformations.box_extrapolation(imgfloat, method=Lanczos4OpenCV())
-    @test typeof(etp) <: Interpolations.FilledExtrapolation
+    @test size(etp) == size(imgfloat)
+    @test eltype(etp) == eltype(imgfloat)
+    @test etp.itp.it == Lanczos4OpenCV()
+    @test etp isa Interpolations.FilledExtrapolation
 end
 
 @testset "AxisAlgorithms.A_ldiv_B_md" begin

--- a/test/interpolations.jl
+++ b/test/interpolations.jl
@@ -42,6 +42,7 @@ end
     for method in (Linear(), BSpline(Linear()), Constant(), BSpline(Constant()))
         etp = @inferred ImageTransformations.box_extrapolation(img, method=method)
         @test @inferred(ImageTransformations.box_extrapolation(etp)) === etp
+        @test_nowarn summary(etp)
         @test size(etp) == size(img)
         @test eltype(etp) == eltype(img)
         @test etp.itp isa Interpolations.BSplineInterpolation
@@ -55,9 +56,10 @@ end
 
     etp = @inferred ImageTransformations.box_extrapolation(img)
     etp2 = @inferred ImageTransformations.box_extrapolation(etp.itp)
-    @test size(etp) == size(img)
-    @test eltype(etp) == eltype(img)
-    @test etp.itp isa Interpolations.BSplineInterpolation
+    @test_nowarn summary(etp2)
+    @test size(etp2) == size(img)
+    @test eltype(etp2) == eltype(img)
+    @test etp2.itp isa Interpolations.BSplineInterpolation
     @test etp2 isa Interpolations.FilledExtrapolation
     @test etp2.fillvalue === Gray{N0f8}(0.0)
     @test etp2 !== etp
@@ -65,6 +67,7 @@ end
 
     etp = @inferred ImageTransformations.box_extrapolation(img)
     etp2 = @inferred ImageTransformations.box_extrapolation(etp.itp, fillvalue=Flat())
+    @test_nowarn summary(etp2)
     @test size(etp2) == size(img)
     @test eltype(etp2) == eltype(img)
     @test etp2.itp isa Interpolations.BSplineInterpolation
@@ -74,6 +77,7 @@ end
     @test etp2.itp === etp.itp
 
     etp = @inferred ImageTransformations.box_extrapolation(img, fillvalue=1)
+    @test_nowarn summary(etp)
     @test size(etp) == size(img)
     @test eltype(etp) == eltype(img)
     @test etp.itp isa Interpolations.BSplineInterpolation
@@ -83,6 +87,7 @@ end
 
     etp = @inferred ImageTransformations.box_extrapolation(img, fillvalue=Flat())
     @test @inferred(ImageTransformations.box_extrapolation(etp)) === etp
+    @test_nowarn summary(etp)
     @test size(etp) == size(img)
     @test eltype(etp) == eltype(img)
     @test etp.itp isa Interpolations.BSplineInterpolation
@@ -91,6 +96,7 @@ end
     @test etp.itp.coefs === img
 
     etp = @inferred ImageTransformations.box_extrapolation(img, method=Constant())
+    @test_nowarn summary(etp)
     @test size(etp) == size(img)
     @test eltype(etp) == eltype(img)
     @test etp.itp.it == BSpline(Constant{Nearest}())
@@ -98,6 +104,7 @@ end
     @test etp.itp.coefs === img
 
     etp = @inferred ImageTransformations.box_extrapolation(img, method=Constant(), fillvalue=Flat())
+    @test_nowarn summary(etp)
     @test size(etp) == size(img)
     @test eltype(etp) == eltype(img)
     @test etp.itp.it == BSpline(Constant{Nearest}())
@@ -107,18 +114,21 @@ end
 
     imgfloat = Float64.(img)
     etp = @inferred ImageTransformations.box_extrapolation(imgfloat, method=Quadratic(Flat(OnGrid())))
+    @test_nowarn summary(etp)
     @test size(etp) == size(imgfloat)
     @test eltype(etp) == eltype(imgfloat)
     @test etp.itp.it == BSpline(Quadratic(Flat(OnGrid())))
     @test etp isa Interpolations.FilledExtrapolation
 
     etp = @inferred ImageTransformations.box_extrapolation(imgfloat, method=Cubic(Flat(OnGrid())), fillvalue=Flat())
+    @test_nowarn summary(etp)
     @test size(etp) == size(imgfloat)
     @test eltype(etp) == eltype(imgfloat)
     @test etp.itp.it == BSpline(Cubic(Flat(OnGrid())))
     @test etp isa Interpolations.Extrapolation
 
     etp = @inferred ImageTransformations.box_extrapolation(imgfloat, method=Lanczos4OpenCV())
+    @test_nowarn summary(etp)
     @test size(etp) == size(imgfloat)
     @test eltype(etp) == eltype(imgfloat)
     @test etp.itp.it == Lanczos4OpenCV()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using CoordinateTransformations, Rotations, TestImages, ImageCore, StaticArrays, OffsetArrays, Interpolations, LinearAlgebra
 using Test, ReferenceTests
+using OffsetArrays: IdentityUnitRange # compat for Julia <1.1
 
 refambs = detect_ambiguities(CoordinateTransformations, Base, Core)
 using ImageTransformations

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,12 +6,6 @@ using ImageTransformations
 ambs = detect_ambiguities(ImageTransformations, CoordinateTransformations, Base, Core)
 @test isempty(setdiff(ambs, refambs))
 
-function typestring(::Type{T}) where T   # from https://github.com/JuliaImages/ImageCore.jl/pull/133
-    buf = IOBuffer()
-    show(buf, T)
-    String(take!(buf))
-end
-
 # helper function to compare NaN
 nearlysame(x, y) = x ≈ y || (isnan(x) & isnan(y))
 nearlysame(A::AbstractArray, B::AbstractArray) = all(map(nearlysame, A, B))

--- a/test/warp.jl
+++ b/test/warp.jl
@@ -1,25 +1,6 @@
 using CoordinateTransformations, Rotations, TestImages, ImageCore, StaticArrays, OffsetArrays, Interpolations, LinearAlgebra
 using Test, ReferenceTests
 
-#img_square = Gray{N0f8}.(reshape(linspace(0,1,9), (3,3)))
-
-SPACE = " " # julia PR #20288
-
-# These module qualifications (used in showarg output) vanished for a while;
-# they are left as variables in case that happens again.
-#ctqual = "ColorTypes."
-#fpqual = "FixedPointNumbers."
-ctqual = ""
-fpqual = ""
-
-if VERSION >= v"1.2.0-DEV.229"
-    sumfmt(rest,img) = Base.dims2string(size(img)) * ' ' * rest
-    sumfmt(ax,rest,img) = Base.dims2string(size(img)) * ' ' * rest * " with indices " * ax
-else
-    sumfmt(rest,img) = rest
-    sumfmt(ax,rest,img) = rest * " with indices " * ax
-end
-
 include("twoints.jl")
 
 img_camera = testimage("camera")
@@ -27,8 +8,6 @@ img_camera = testimage("camera")
     tfm = recenter(RotMatrix(pi/8), center(img_camera))
     ref_inds = (-78:591, -78:591)
     ref_size = map(length,ref_inds)
-    n0f8_str = typestring(N0f8)
-    matrixf64_str = typestring(Matrix{Float64})
 
     @testset "warp" begin
         imgr = @inferred(warp(img_camera, tfm))
@@ -102,7 +81,6 @@ img_camera = testimage("camera")
 
     @testset "WarpedView" begin
         imgr = @inferred(WarpedView(img_camera, tfm))
-        @test summary(imgr) == sumfmt("-78:591×-78:591","WarpedView(::Array{Gray{N0f8},2}, $(imgr.transform)) with eltype $(ctqual)Gray{$(fpqual)$n0f8_str}", imgr)
         @test @inferred(getindex(imgr,2,2)) == imgr[2,2]
         @test typeof(imgr[2,2]) == eltype(imgr)
         @test size(imgr) == ref_size
@@ -116,7 +94,6 @@ img_camera = testimage("camera")
         @test_reference "reference/warp_cameraman_rotate_r22deg_crop.txt" imgr2
 
         imgr = @inferred(WarpedView(img_camera, tfm, axes(img_camera)))
-        @test summary(imgr) == "512×512 WarpedView(::Array{Gray{N0f8},2}, $(imgr.transform)) with eltype $(ctqual)Gray{$(fpqual)$n0f8_str}"
         @test @inferred(size(imgr)) == size(img_camera)
         @test @inferred(size(imgr,3)) == 1
         @test parent(imgr) === img_camera
@@ -126,32 +103,26 @@ img_camera = testimage("camera")
         @test_reference "reference/warp_cameraman_rotate_r22deg_crop.txt" imgr
 
         imgr = @inferred(WarpedView(img_camera, tfm, axes(img_camera); fillvalue=1))
-        # @test summary(imgr) == "512×512 WarpedView(extrapolate(interpolate(::Array{Gray{N0f8},2}, BSpline(Linear())), Gray{N0f8}(1.0)), $(imgr.transform)) with eltype $(ctqual)Gray{$(fpqual)$n0f8_str}"
         @test @inferred(size(imgr)) == size(img_camera)
         @test @inferred(size(imgr,3)) == 1
-        # @test typeof(parent(imgr)) <: Interpolations.FilledExtrapolation
-        # @test parent(imgr).itp.coefs === img_camera
+        @test parent(imgr) === img_camera
         @test axes(imgr) === axes(img_camera)
         @test typeof(imgr) <: WarpedView
         @test eltype(imgr) == eltype(img_camera)
         @test_reference "reference/warp_cameraman_rotate_r22deg_crop_white.txt" imgr
 
         imgr = @inferred(WarpedView(img_camera, tfm, axes(img_camera); method=Linear(), fillvalue=1))
-        # @test summary(imgr) == "512×512 WarpedView(extrapolate(interpolate(::Array{Gray{N0f8},2}, BSpline(Linear())), Gray{N0f8}(1.0)), $(imgr.transform)) with eltype $(ctqual)Gray{$(fpqual)$n0f8_str}"
         @test @inferred(size(imgr)) == size(img_camera)
         @test @inferred(size(imgr,3)) == 1
-        # @test typeof(parent(imgr)) <: Interpolations.FilledExtrapolation
-        # @test parent(imgr).itp.coefs === img_camera
+        @test parent(imgr) === img_camera
         @test axes(imgr) === axes(img_camera)
         @test typeof(imgr) <: WarpedView
         @test eltype(imgr) == eltype(img_camera)
         @test_reference "reference/warp_cameraman_rotate_r22deg_crop_white.txt" imgr
 
         imgr = @inferred(WarpedView(img_camera, tfm; fillvalue=1))
-        # @test summary(imgr) == sumfmt("-78:591×-78:591","WarpedView(extrapolate(interpolate(::Array{Gray{N0f8},2}, BSpline(Linear())), Gray{N0f8}(1.0)), $(imgr.transform)) with eltype $(ctqual)Gray{$(fpqual)$n0f8_str}", imgr)
         @test size(imgr) == ref_size
-        # @test typeof(parent(imgr)) <: Interpolations.FilledExtrapolation
-        # @test parent(imgr).itp.coefs === img_camera
+        @test parent(imgr) === img_camera
         @test typeof(imgr) <: WarpedView
         @test eltype(imgr) == eltype(img_camera)
         @test_reference "reference/warp_cameraman_rotate_r22deg_white.txt" imgr
@@ -162,10 +133,8 @@ img_camera = testimage("camera")
         # @test imgr2[axes(img_camera)...] ≈ img_camera
 
         imgr = @inferred(WarpedView(img_camera, tfm; fillvalue=Flat()))
-        # @test summary(imgr) == sumfmt("-78:591×-78:591","WarpedView(extrapolate(interpolate(::Array{Gray{N0f8},2}, BSpline(Linear())), Flat()), $(imgr.transform)) with eltype $(ctqual)Gray{$(fpqual)$n0f8_str}", imgr)
         @test size(imgr) == ref_size
-        # @test typeof(parent(imgr)) <: Interpolations.Extrapolation
-        # @test parent(imgr).itp.coefs === img_camera
+        @test parent(imgr) === img_camera
         @test typeof(imgr) <: WarpedView
         @test eltype(imgr) == eltype(img_camera)
         @test_reference "reference/warp_cameraman_rotate_r22deg_flat.txt" imgr
@@ -175,23 +144,15 @@ img_camera = testimage("camera")
         @test_reference "reference/warp_cameraman_rotate_r22deg_flat.txt" imgr
 
         imgr = @inferred(WarpedView(img_camera, tfm; method=Constant(), fillvalue=Periodic()))
-        # str = summary(imgr)
-        # @test occursin(sumfmt("WarpedView(extrapolate(interpolate(::Array{Gray{N0f8},2}, BSpline(Constant", imgr), str) &&
-        #       occursin("Periodic()), $(imgr.transform)) with eltype $(ctqual)Gray{$(fpqual)$n0f8_str}", str) &&
-        #       occursin("with indices -78:591×-78:591", str)
         @test size(imgr) == ref_size
-        # @test typeof(parent(imgr)) <: Interpolations.Extrapolation
-        # @test parent(imgr).itp.coefs === img_camera
+        @test parent(imgr) === img_camera
         @test typeof(imgr) <: WarpedView
         @test eltype(imgr) == eltype(img_camera)
         @test_reference "reference/warp_cameraman_rotate_r22deg_periodic.txt" imgr
 
         imgr = @inferred(WarpedView(img_camera, tfm, ref_inds; method=Constant(), fillvalue=Periodic()))
-        # str = summary(imgr)
-        # @test occursin(sumfmt("WarpedView(extrapolate(interpolate(::Array{Gray{N0f8},2}, BSpline(Constant", imgr), str) &&
-        #       occursin("Periodic()), $(imgr.transform)) with eltype $(ctqual)Gray{$(fpqual)$n0f8_str}", str) &&
-        #       occursin("with indices -78:591×-78:591", str)
         @test size(imgr) == ref_size
+        @test parent(imgr) === img_camera
         @test eltype(imgr) == eltype(img_camera)
         @test_reference "reference/warp_cameraman_rotate_r22deg_periodic.txt" imgr
     end
@@ -212,13 +173,13 @@ img_camera = testimage("camera")
         @test axes(wv2) == axes(img_camera)
         @test eltype(wv2) === eltype(img_camera)
         @test parent(wv2) === img_camera
-        # @test wv2 ≈ img_camera # FIXME
+        @test wv2 ≈ img_camera
 
         imgr = @inferred(invwarpedview(img_camera, tfm))
         @test imgr == @inferred(InvWarpedView(img_camera, tfm))
-        # @test summary(imgr) == sumfmt("-78:591×-78:591","InvWarpedView(::Array{Gray{N0f8},2}, $(imgr.inverse)) with eltype $(ctqual)Gray{$(fpqual)$n0f8_str}", imgr)
         @test size(imgr) == ref_size
-        # @test parent(imgr) === img_camera # FIXME
+        @test parent(imgr) isa Interpolations.FilledExtrapolation
+        @test parent(imgr).itp.coefs === img_camera
         @test typeof(imgr) <: InvWarpedView
         @test axes(imgr) == ref_inds
         @test eltype(imgr) == eltype(img_camera)
@@ -229,17 +190,16 @@ img_camera = testimage("camera")
 
         imgr = @inferred(invwarpedview(img_camera, tfm, axes(img_camera)))
         @test imgr == @inferred(InvWarpedView(img_camera, tfm, axes(img_camera)))
-        # @test summary(imgr) == "512×512 InvWarpedView(::Array{Gray{N0f8},2}, $(imgr.inverse)) with eltype $(ctqual)Gray{$(fpqual)$n0f8_str}"
         @test @inferred(size(imgr)) == size(img_camera)
         @test @inferred(size(imgr,3)) == 1
-        # @test parent(imgr) === img_camera
+        @test parent(imgr) isa Interpolations.FilledExtrapolation
+        @test parent(imgr).itp.coefs === img_camera
         @test axes(imgr) === axes(img_camera)
         @test typeof(imgr) <: InvWarpedView
         @test eltype(imgr) == eltype(img_camera)
         @test_reference "reference/warp_cameraman_rotate_r22deg_crop.txt" imgr
 
         imgr = @inferred(invwarpedview(img_camera, tfm, axes(img_camera); fillvalue=1))
-        @test summary(imgr) == "512×512 InvWarpedView(extrapolate(interpolate(::Array{Gray{N0f8},2}, BSpline(Linear())), Gray{N0f8}(1.0)), $(imgr.inverse)) with eltype $(ctqual)Gray{$(fpqual)$n0f8_str}"
         @test @inferred(size(imgr)) == size(img_camera)
         @test @inferred(size(imgr,3)) == 1
         @test typeof(parent(imgr)) <: Interpolations.FilledExtrapolation
@@ -250,7 +210,6 @@ img_camera = testimage("camera")
         @test_reference "reference/warp_cameraman_rotate_r22deg_crop_white.txt" imgr
 
         imgr = @inferred(invwarpedview(img_camera, tfm, axes(img_camera); method=Linear(), fillvalue=1))
-        @test summary(imgr) == "512×512 InvWarpedView(extrapolate(interpolate(::Array{Gray{N0f8},2}, BSpline(Linear())), Gray{N0f8}(1.0)), $(imgr.inverse)) with eltype $(ctqual)Gray{$(fpqual)$n0f8_str}"
         @test @inferred(size(imgr)) == size(img_camera)
         @test @inferred(size(imgr,3)) == 1
         @test typeof(parent(imgr)) <: Interpolations.FilledExtrapolation
@@ -261,7 +220,6 @@ img_camera = testimage("camera")
         @test_reference "reference/warp_cameraman_rotate_r22deg_crop_white.txt" imgr
 
         imgr = @inferred(invwarpedview(img_camera, tfm; fillvalue=1))
-        @test summary(imgr) == sumfmt("-78:591×-78:591","InvWarpedView(extrapolate(interpolate(::Array{Gray{N0f8},2}, BSpline(Linear())), Gray{N0f8}(1.0)), $(imgr.inverse)) with eltype $(ctqual)Gray{$(fpqual)$n0f8_str}", imgr)
         @test size(imgr) == ref_size
         @test typeof(parent(imgr)) <: Interpolations.FilledExtrapolation
         @test parent(imgr).itp.coefs === img_camera
@@ -270,7 +228,6 @@ img_camera = testimage("camera")
         @test_reference "reference/warp_cameraman_rotate_r22deg_white.txt" imgr
 
         imgr = @inferred(invwarpedview(img_camera, tfm; fillvalue=Flat()))
-        @test summary(imgr) == sumfmt("-78:591×-78:591","InvWarpedView(extrapolate(interpolate(::Array{Gray{N0f8},2}, BSpline(Linear())), Flat()), $(imgr.inverse)) with eltype $(ctqual)Gray{$(fpqual)$n0f8_str}", imgr)
         @test size(imgr) == ref_size
         @test typeof(parent(imgr)) <: Interpolations.Extrapolation
         @test parent(imgr).itp.coefs === img_camera
@@ -283,11 +240,8 @@ img_camera = testimage("camera")
         @test_reference "reference/warp_cameraman_rotate_r22deg_flat.txt" imgr
 
         imgr = @inferred(invwarpedview(img_camera, tfm; method=Constant(), fillvalue=Periodic()))
-        str = summary(imgr)
-        @test occursin(sumfmt("InvWarpedView(extrapolate(interpolate(::Array{Gray{N0f8},2}, BSpline(Constant", imgr), str) &&
-              occursin("Periodic()), $(imgr.inverse)) with eltype $(ctqual)Gray{$(fpqual)$n0f8_str}", str) &&
-              occursin("with indices -78:591×-78:591", str)
         @test size(imgr) == ref_size
+        @test axes(imgr) == ref_inds
         @test typeof(parent(imgr)) <: Interpolations.Extrapolation
         @test parent(imgr).itp.coefs === img_camera
         @test typeof(imgr) <: InvWarpedView
@@ -295,11 +249,8 @@ img_camera = testimage("camera")
         @test_reference "reference/warp_cameraman_rotate_r22deg_periodic.txt" imgr
 
         imgr = @inferred(invwarpedview(img_camera, tfm, ref_inds; method=Constant(), fillvalue=Periodic()))
-        str = summary(imgr)
-        @test occursin(sumfmt("InvWarpedView(extrapolate(interpolate(::Array{Gray{N0f8},2}, BSpline(Constant", imgr), str) &&
-              occursin("Periodic()), $(imgr.inverse)) with eltype $(ctqual)Gray{$(fpqual)$n0f8_str}", str) &&
-              occursin("with indices -78:591×-78:591", str)
         @test size(imgr) == ref_size
+        @test axes(imgr) == ref_inds
         @test eltype(imgr) == eltype(img_camera)
         @test_reference "reference/warp_cameraman_rotate_r22deg_periodic.txt" imgr
     end
@@ -309,7 +260,11 @@ img_camera = testimage("camera")
         wv = @inferred(InvWarpedView(img_camera, tfm))
         # tight crop that barely contains head and camera
         v = @inferred view(wv, 75:195, 245:370)
-        @test summary(v) == "121×126 view(InvWarpedView(::Array{Gray{N0f8},2}, $(wv.inverse)), 75:195, 245:370) with eltype $(ctqual)Gray{$(fpqual)$n0f8_str}"
+        @test axes(v) == (1:121, 1:126)
+        @test v.indices == (75:195, 245:370)
+        @test axes(parent(v)) == (-78:591, -78:591)
+        @test eltype(v) == eltype(img_camera)
+
         tfm2 = AffineMap(@SMatrix([0.6 0.;0. 0.8]), @SVector([10.,50.]))
         # this should still be a tight crop that
         # barely contains head and camera !
@@ -319,7 +274,10 @@ img_camera = testimage("camera")
         @test typeof(parent(wv2)) <: InvWarpedView
         @test typeof(parent(wv2)) <: InvWarpedView
         @test parent(parent(wv2)) === img_camera
-        # @test summary(wv2) == sumfmt("55:127×246:346","view(InvWarpedView(::Array{Gray{N0f8},2}, $(parent(wv2).inverse)), IdentityRange(55:127), IdentityRange(246:346)) with eltype $(ctqual)Gray{$(fpqual)$n0f8_str}", wv2)
+        @test wv2.indices === axes(wv2) === (Base.IdentityUnitRange(55:127), Base.IdentityUnitRange(246:346))
+        @test axes(parent(wv2)) == (-37:365, -13:523)
+        @test eltype(wv2) == eltype(img_camera)
+
         @test_reference "reference/warp_cameraman_rotate_crop_scale.txt" wv2
         wv3 = @inferred invwarpedview(v, tfm2, wv2.indices)
         @test wv3 == wv2
@@ -330,7 +288,10 @@ img_camera = testimage("camera")
         tfm = recenter(RotMatrix(-pi/8), center(float_array))
         wv = @inferred(InvWarpedView(float_array, tfm))
         v = @inferred view(wv, 1:10, 1:10)
-        @test summary(v) == "10×10 view(InvWarpedView(::$matrixf64_str, $(wv.inverse)), 1:10, 1:10) with eltype Float64"
+        @test axes(v) == (1:10, 1:10)
+        @test eltype(v) == eltype(float_array)
+        @test any(isnan, v)
+        @test parent(v) isa InvWarpedView
     end
 end
 
@@ -456,8 +417,9 @@ NaN  NaN      NaN      NaN      NaN      NaN      NaN
             itp = interpolate(img_pyramid_cntr, BSpline(Quadratic(Flat(OnCell()))))
             imgrq_cntr = InvWarpedView(itp, inv(tfm2))
             @test parent(imgrq_cntr) === itp
-            @test summary(imgrq_cntr) == sumfmt("-3:3×-3:3","InvWarpedView(interpolate(OffsetArray(::Array{Gray{Float64},2}, -3:3, -3:3), BSpline(Quadratic(Flat(OnCell())))), $(imgrq_cntr.inverse)) with eltype $(ctqual)Gray{Float64}", imgr)
             @test axes(imgrq_cntr) == (-3:3, -3:3)
+            @test eltype(imgrq_cntr) == eltype(img_pyramid_cntr)
+
             @test nearlysame(round.(Float64.(imgrq_cntr[axes(imgrq_cntr)...]), digits=3), round.(ref_img_pyramid_quad, digits=3))
         end
     end

--- a/test/warp.jl
+++ b/test/warp.jl
@@ -81,6 +81,7 @@ img_camera = testimage("camera")
 
     @testset "WarpedView" begin
         imgr = @inferred(WarpedView(img_camera, tfm))
+        @test_nowarn summary(imgr)
         @test @inferred(getindex(imgr,2,2)) == imgr[2,2]
         @test typeof(imgr[2,2]) == eltype(imgr)
         @test size(imgr) == ref_size
@@ -94,6 +95,7 @@ img_camera = testimage("camera")
         @test_reference "reference/warp_cameraman_rotate_r22deg_crop.txt" imgr2
 
         imgr = @inferred(WarpedView(img_camera, tfm, axes(img_camera)))
+        @test_nowarn summary(imgr)
         @test @inferred(size(imgr)) == size(img_camera)
         @test @inferred(size(imgr,3)) == 1
         @test parent(imgr) === img_camera
@@ -103,6 +105,7 @@ img_camera = testimage("camera")
         @test_reference "reference/warp_cameraman_rotate_r22deg_crop.txt" imgr
 
         imgr = @inferred(WarpedView(img_camera, tfm, axes(img_camera); fillvalue=1))
+        @test_nowarn summary(imgr)
         @test @inferred(size(imgr)) == size(img_camera)
         @test @inferred(size(imgr,3)) == 1
         @test parent(imgr) === img_camera
@@ -112,6 +115,7 @@ img_camera = testimage("camera")
         @test_reference "reference/warp_cameraman_rotate_r22deg_crop_white.txt" imgr
 
         imgr = @inferred(WarpedView(img_camera, tfm, axes(img_camera); method=Linear(), fillvalue=1))
+        @test_nowarn summary(imgr)
         @test @inferred(size(imgr)) == size(img_camera)
         @test @inferred(size(imgr,3)) == 1
         @test parent(imgr) === img_camera
@@ -121,6 +125,7 @@ img_camera = testimage("camera")
         @test_reference "reference/warp_cameraman_rotate_r22deg_crop_white.txt" imgr
 
         imgr = @inferred(WarpedView(img_camera, tfm; fillvalue=1))
+        @test_nowarn summary(imgr)
         @test size(imgr) == ref_size
         @test parent(imgr) === img_camera
         @test typeof(imgr) <: WarpedView
@@ -133,6 +138,7 @@ img_camera = testimage("camera")
         # @test imgr2[axes(img_camera)...] ≈ img_camera
 
         imgr = @inferred(WarpedView(img_camera, tfm; fillvalue=Flat()))
+        @test_nowarn summary(imgr)
         @test size(imgr) == ref_size
         @test parent(imgr) === img_camera
         @test typeof(imgr) <: WarpedView
@@ -144,6 +150,7 @@ img_camera = testimage("camera")
         @test_reference "reference/warp_cameraman_rotate_r22deg_flat.txt" imgr
 
         imgr = @inferred(WarpedView(img_camera, tfm; method=Constant(), fillvalue=Periodic()))
+        @test_nowarn summary(imgr)
         @test size(imgr) == ref_size
         @test parent(imgr) === img_camera
         @test typeof(imgr) <: WarpedView
@@ -151,6 +158,7 @@ img_camera = testimage("camera")
         @test_reference "reference/warp_cameraman_rotate_r22deg_periodic.txt" imgr
 
         imgr = @inferred(WarpedView(img_camera, tfm, ref_inds; method=Constant(), fillvalue=Periodic()))
+        @test_nowarn summary(imgr)
         @test size(imgr) == ref_size
         @test parent(imgr) === img_camera
         @test eltype(imgr) == eltype(img_camera)
@@ -177,6 +185,7 @@ img_camera = testimage("camera")
 
         imgr = @inferred(invwarpedview(img_camera, tfm))
         @test imgr == @inferred(InvWarpedView(img_camera, tfm))
+        @test_nowarn summary(imgr)
         @test size(imgr) == ref_size
         @test parent(imgr) isa Interpolations.FilledExtrapolation
         @test parent(imgr).itp.coefs === img_camera
@@ -190,6 +199,7 @@ img_camera = testimage("camera")
 
         imgr = @inferred(invwarpedview(img_camera, tfm, axes(img_camera)))
         @test imgr == @inferred(InvWarpedView(img_camera, tfm, axes(img_camera)))
+        @test_nowarn summary(imgr)
         @test @inferred(size(imgr)) == size(img_camera)
         @test @inferred(size(imgr,3)) == 1
         @test parent(imgr) isa Interpolations.FilledExtrapolation
@@ -200,6 +210,7 @@ img_camera = testimage("camera")
         @test_reference "reference/warp_cameraman_rotate_r22deg_crop.txt" imgr
 
         imgr = @inferred(invwarpedview(img_camera, tfm, axes(img_camera); fillvalue=1))
+        @test_nowarn summary(imgr)
         @test @inferred(size(imgr)) == size(img_camera)
         @test @inferred(size(imgr,3)) == 1
         @test typeof(parent(imgr)) <: Interpolations.FilledExtrapolation
@@ -210,6 +221,7 @@ img_camera = testimage("camera")
         @test_reference "reference/warp_cameraman_rotate_r22deg_crop_white.txt" imgr
 
         imgr = @inferred(invwarpedview(img_camera, tfm, axes(img_camera); method=Linear(), fillvalue=1))
+        @test_nowarn summary(imgr)
         @test @inferred(size(imgr)) == size(img_camera)
         @test @inferred(size(imgr,3)) == 1
         @test typeof(parent(imgr)) <: Interpolations.FilledExtrapolation
@@ -220,6 +232,7 @@ img_camera = testimage("camera")
         @test_reference "reference/warp_cameraman_rotate_r22deg_crop_white.txt" imgr
 
         imgr = @inferred(invwarpedview(img_camera, tfm; fillvalue=1))
+        @test_nowarn summary(imgr)
         @test size(imgr) == ref_size
         @test typeof(parent(imgr)) <: Interpolations.FilledExtrapolation
         @test parent(imgr).itp.coefs === img_camera
@@ -228,6 +241,7 @@ img_camera = testimage("camera")
         @test_reference "reference/warp_cameraman_rotate_r22deg_white.txt" imgr
 
         imgr = @inferred(invwarpedview(img_camera, tfm; fillvalue=Flat()))
+        @test_nowarn summary(imgr)
         @test size(imgr) == ref_size
         @test typeof(parent(imgr)) <: Interpolations.Extrapolation
         @test parent(imgr).itp.coefs === img_camera
@@ -240,6 +254,7 @@ img_camera = testimage("camera")
         @test_reference "reference/warp_cameraman_rotate_r22deg_flat.txt" imgr
 
         imgr = @inferred(invwarpedview(img_camera, tfm; method=Constant(), fillvalue=Periodic()))
+        @test_nowarn summary(imgr)
         @test size(imgr) == ref_size
         @test axes(imgr) == ref_inds
         @test typeof(parent(imgr)) <: Interpolations.Extrapolation
@@ -249,6 +264,7 @@ img_camera = testimage("camera")
         @test_reference "reference/warp_cameraman_rotate_r22deg_periodic.txt" imgr
 
         imgr = @inferred(invwarpedview(img_camera, tfm, ref_inds; method=Constant(), fillvalue=Periodic()))
+        @test_nowarn summary(imgr)
         @test size(imgr) == ref_size
         @test axes(imgr) == ref_inds
         @test eltype(imgr) == eltype(img_camera)
@@ -260,6 +276,7 @@ img_camera = testimage("camera")
         wv = @inferred(InvWarpedView(img_camera, tfm))
         # tight crop that barely contains head and camera
         v = @inferred view(wv, 75:195, 245:370)
+        @test_nowarn summary(v)
         @test axes(v) == (1:121, 1:126)
         @test v.indices == (75:195, 245:370)
         @test axes(parent(v)) == (-78:591, -78:591)
@@ -274,7 +291,8 @@ img_camera = testimage("camera")
         @test typeof(parent(wv2)) <: InvWarpedView
         @test typeof(parent(wv2)) <: InvWarpedView
         @test parent(parent(wv2)) === img_camera
-        @test wv2.indices === axes(wv2) === (Base.IdentityUnitRange(55:127), Base.IdentityUnitRange(246:346))
+        @test_nowarn summary(wv2)
+        @test wv2.indices === axes(wv2) === (IdentityUnitRange(55:127), IdentityUnitRange(246:346))
         @test axes(parent(wv2)) == (-37:365, -13:523)
         @test eltype(wv2) == eltype(img_camera)
 
@@ -288,6 +306,7 @@ img_camera = testimage("camera")
         tfm = recenter(RotMatrix(-pi/8), center(float_array))
         wv = @inferred(InvWarpedView(float_array, tfm))
         v = @inferred view(wv, 1:10, 1:10)
+        @test_nowarn summary(v)
         @test axes(v) == (1:10, 1:10)
         @test eltype(v) == eltype(float_array)
         @test any(isnan, v)
@@ -417,6 +436,7 @@ NaN  NaN      NaN      NaN      NaN      NaN      NaN
             itp = interpolate(img_pyramid_cntr, BSpline(Quadratic(Flat(OnCell()))))
             imgrq_cntr = InvWarpedView(itp, inv(tfm2))
             @test parent(imgrq_cntr) === itp
+            @test_nowarn summary(imgrq_cntr)
             @test axes(imgrq_cntr) == (-3:3, -3:3)
             @test eltype(imgrq_cntr) == eltype(img_pyramid_cntr)
 


### PR DESCRIPTION
`summary` results are not very stable; it differs from version to version. Hence I replace all `summary` tests with `axes`, `eltype` and `size` tests.