### PR TITLE
WIP: use StaticArraysCore

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,6 +12,7 @@ Interpolations = "a98d9a8b-a2ab-59e6-89dd-64a1c18fca59"
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 Rotations = "6038ab10-8711-5258-84ad-4b1120ba62dc"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+StaticArraysCore = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
 
 [compat]
 AxisAlgorithms = "0.3, 1.0"
@@ -22,7 +23,7 @@ ImageCore = "0.8.1, 0.9"
 Interpolations = "0.13.4, 0.14"
 OffsetArrays = "0.10, 0.11, 1.0.1"
 Rotations = "0.12, 0.13, 1.0"
-StaticArrays = "0.10, 0.11, 0.12, 1.0"
+StaticArraysCore = "1"
 julia = "1"
 
 [extras]
@@ -31,9 +32,10 @@ ImageIO = "82e4d734-157c-48bb-816b-45c225c6df19"
 ImageMagick = "6218d12a-5da1-5696-b52f-db25d2ecc6d1"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 ReferenceTests = "324d217c-45ce-50fc-942e-d289b448e8cf"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Tau = "c544e3c2-d3e5-5802-ac44-44683f340e4a"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TestImages = "5e47fb64-e119-507b-a336-dd2b206d9990"
 
 [targets]
-test = ["EndpointRanges", "ImageIO", "ImageMagick", "LinearAlgebra", "ReferenceTests", "Tau", "Test", "TestImages"]
+test = ["EndpointRanges", "ImageIO", "ImageMagick", "LinearAlgebra", "ReferenceTests", "StaticArrays", "Tau", "Test", "TestImages"]

--- a/src/ImageTransformations.jl
+++ b/src/ImageTransformations.jl
@@ -40,7 +40,7 @@ module ImageTransformations
 using ImageCore
 using CoordinateTransformations
 using Rotations
-using StaticArrays
+using StaticArraysCore
 using Interpolations, AxisAlgorithms
 using OffsetArrays
 using ColorVectorSpace
@@ -73,8 +73,8 @@ include("compat.jl")
 include("deprecated.jl")
 
 # TODO: move to warp.jl
-@inline _getindex(A, v::StaticVector) = A[Tuple(v)...]
-@inline _getindex(A::AbstractInterpolation, v::StaticVector) = A(Tuple(v)...)
+@inline _getindex(A, v::StaticArraysCore.StaticVector) = A[Tuple(v)...]
+@inline _getindex(A::AbstractInterpolation, v::StaticArraysCore.StaticVector) = A(Tuple(v)...)
 @inline _getindex(A, v) = A[v...]
 @inline _getindex(A::AbstractInterpolation, v) = A(v...)
 

--- a/src/warp.jl
+++ b/src/warp.jl
@@ -258,11 +258,11 @@ function rotmtrx2(θ::T) where T<:Real
     θ = _mod2pi(θ)
     FT = floattype(T)
     if abs(θ) <= Δ || abs(θ - 2π) <= Δ
-        return RotMatrix{2,FT}(@SMatrix [1 0; 0 1])
+        return RotMatrix{2,FT}(SMatrix{2,2}([1 0; 0 1]))
     elseif abs(θ - π) <= Δ
-        return RotMatrix{2,FT}(@SMatrix [-1 0; 0 -1])
+        return RotMatrix{2,FT}(SMatrix{2,2}([-1 0; 0 -1]))
     else
         return RotMatrix{2,FT}(θ)
     end
 end
-rotmtrx2(θ::Irrational{:π}) = RotMatrix(@SMatrix [-1 0; 0 -1])
+rotmtrx2(θ::Irrational{:π}) = RotMatrix(SMatrix{2,2}([-1 0; 0 -1]))

--- a/test/autorange.jl
+++ b/test/autorange.jl
@@ -132,10 +132,4 @@ end
     tst_img = zeros(5,5)
     rnge = ImageTransformations.autorange(tst_img, tfm_s)
     @test rnge == ImageTransformations.autorange(tst_img, tfm)
-    # ComposedFunction (issue #110)
-    M = @SMatrix [1 0 0; 0 1 0; -1/1000 0 1] 
-    push1(x) = push(x, 1)
-    tfm = PerspectiveMap() ∘ inv(LinearMap(M)) ∘ push1
-    tst_img = zeros(5, 5)
-    @test ImageTransformations.autorange(tst_img, tfm) == (0:5, 0:5)
 end

--- a/test/interpolations.jl
+++ b/test/interpolations.jl
@@ -52,7 +52,7 @@ end
     end
 
     # to catch regressions like #60
-    @test @inferred(ImageTransformations._getindex(img, @SVector([1,2]))) isa Gray{N0f8}
+    @test @inferred(ImageTransformations._getindex(img, SVector{2}([1,2]))) isa Gray{N0f8}
 
     etp = @inferred ImageTransformations.box_extrapolation(img)
     etp2 = @inferred ImageTransformations.box_extrapolation(etp.itp)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,5 @@
-using CoordinateTransformations, Rotations, TestImages, ImageCore, StaticArrays, OffsetArrays, Interpolations, LinearAlgebra
+using CoordinateTransformations, Rotations, TestImages, ImageCore, OffsetArrays, Interpolations, LinearAlgebra
+using StaticArraysCore
 using Test, ReferenceTests
 
 refambs = detect_ambiguities(CoordinateTransformations, Base, Core)
@@ -24,6 +25,11 @@ for t in tests
         include(t)
     end
 end
+
+# put StaticArrays-related test at the end of the test to ensure the functionality works
+# without `using StaticArrays`
+using StaticArrays
+include("staticarrays.jl")
 end
 
 nothing

--- a/test/staticarrays.jl
+++ b/test/staticarrays.jl
@@ -1,0 +1,8 @@
+@testset "StaticArrays" begin
+    # ComposedFunction (issue #110)
+    M = SMatrix{3,3}([1 0 0; 0 1 0; -1/1000 0 1])
+    push1(x) = push(x, 1)
+    tfm = PerspectiveMap() ∘ inv(LinearMap(M)) ∘ push1
+    tst_img = zeros(5, 5)
+    @test ImageTransformations.autorange(tst_img, tfm) == (0:5, 0:5)
+end

--- a/test/warp.jl
+++ b/test/warp.jl
@@ -1,4 +1,4 @@
-using CoordinateTransformations, Rotations, TestImages, ImageCore, StaticArrays, OffsetArrays, Interpolations, LinearAlgebra
+using CoordinateTransformations, Rotations, TestImages, ImageCore, OffsetArrays, Interpolations, LinearAlgebra
 using EndpointRanges
 using Tau
 using Test, ReferenceTests


### PR DESCRIPTION
People are blaming ImageTransformations too heavy to load. One of the main latency comes from StaticArrays by checking `@time_imports` (in Julia 1.8)