### PR TITLE
Update to Documenter.jl v1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 *.jl.*.cov
 *.jl.mem
 Manifest.toml
+docs/build
+docs/examples

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@
 *.jl.mem
 Manifest.toml
 docs/build
-docs/examples

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -16,5 +16,5 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 TestImages = "5e47fb64-e119-507b-a336-dd2b206d9990"
 
 [compat]
-DemoCards = "0.4"
-Documenter = "0.27"
+DemoCards = "0.4, 0.5"
+Documenter = "0.27, 1"

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -1,0 +1,3 @@
+# Examples
+
+{{{democards}}}

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,4 +1,5 @@
 using Documenter, DemoCards
+using Documenter.Remotes: GitHub
 using ImageBase, ImageTransformations, ImageShow
 using TestImages
 using CoordinateTransformations, Interpolations, Rotations
@@ -9,15 +10,17 @@ testimage.(["cameraman", "lighthouse"])
 examples, postprocess_cb, examples_assets = makedemos("examples")
 format = Documenter.HTML(edit_link = "master",
                          prettyurls = get(ENV, "CI", nothing) == "true",
-                         assets = [examples_assets,])
+                         assets = [examples_assets,], size_threshold = nothing)
 
 makedocs(modules  = [ImageTransformations, ImageBase],
+         repo     = GitHub("JuliaImages/ImageTransformations.jl"),
          format   = format,
          sitename = "ImageTransformations",
          pages    = [
              "index.md",
              examples,
-             "reference.md"])
+             "reference.md"],
+         warnonly = [:missing_docs])
 
 postprocess_cb()
 


### PR DESCRIPTION
Howdy, would something like this be alright?

I found myself wanting to link to some functions here with DocumenterInterLinks.jl, but I think the docs need to be re-built with a more recent version of Documenter.jl first so that the `objects.inv` file can be created.