### PR TITLE
CI: fix macOS arch for Apple Silicon runners

### DIFF
--- a/.github/workflows/UnitTest.yml
+++ b/.github/workflows/UnitTest.yml
@@ -23,13 +23,13 @@ jobs:
             arch: x64
           - os: macOS-latest
             julia-version: '1'
-            arch: x64
+            arch: aarch64
 
 
     steps:
       - uses: actions/checkout@v6
       - name: "Set up Julia"
-        uses: julia-actions/setup-julia@v2
+        uses: julia-actions/setup-julia@v3
         with:
           version: ${{ matrix.julia-version }}
           arch: ${{ matrix.arch }}
@@ -41,4 +41,4 @@ jobs:
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v7
         with:
-          file: lcov.info
+          files: lcov.info


### PR DESCRIPTION
`macOS-latest` GitHub runners are now Apple Silicon (arm64). `setup-julia@v3` errors when `arch: x64` is requested on them, so the macOS jobs fail.

This configures the matrix to use the correct native architecture (default per-runner for single-arch matrices; explicit `exclude`/`include` for multi-arch matrices) and bumps `julia-actions/setup-julia` to v3.

Closes #180
